### PR TITLE
Pip-488 - Setup the Accessibility tests for the route pages

### DIFF
--- a/src/main/views/template.njk
+++ b/src/main/views/template.njk
@@ -16,7 +16,7 @@
         navigationClasses: 'nav-right',
         navigation: [
             {
-              href: "#signIn",
+              href: "#",
               text: "Sign in",
               active: false
             }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "target": "es6",
-    "noImplicitAny": true,
+    "noImplicitAny": false,
     "moduleResolution": "node",
     "noUnusedLocals": true,
     "experimentalDecorators": true,


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link ###
https://tools.hmcts.net/jira/browse/PUB-488


### Change description ###
Automated the accessibility tests so that they are updated by default when a new page is added.
files are read from the `routes` folder and trimmed, this relies on us naming the file the same as the route, which we should aim for anyway and have been doing, eg we have `home.ts` and `search-option.ts` which is trimmed and added to to create `/home` and `/search-option`.

info and health have been excluded due to them not being forward facing

edited tsconfig to remove the rule of not allowing an `any` type


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
