### PR TITLE
pub-508 - Added search results list

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -5,3 +5,8 @@ files:
 rules:
   class-name-format:
     - 0
+  placeholder-in-extend:
+    - 0
+  nesting-depth:
+    - 1
+    - max-depth: 4

--- a/src/main/assets/scss/main.scss
+++ b/src/main/assets/scss/main.scss
@@ -11,22 +11,34 @@
   font-weight: inherit;
 }
 
-tbody > tr:first-child > th.govuk-table__cell--no-line{
-  border-style: inherit!important;
+tbody {
+  tr {
+    &:first-child {
+      th {
+        &.govuk-table__cell--no-line {
+          border-style: inherit;
+        }
+      }
+
+      td {
+        &.govuk-table__cell--no-line {
+          border-top: 1px solid $govuk-border-colour;
+        }
+      }
+    }
+
+    &:last-child {
+      th {
+        &.govuk-table__cell--no-line {
+          border-bottom-style: solid;
+        }
+      }
+
+      td {
+        &.govuk-table__cell--no-line {
+          border-bottom-style: solid;
+        }
+      }
+    }
+  }
 }
-tbody > tr:first-child > td.govuk-table__cell--no-line{
-  border-top: 1px solid $govuk-border-colour !important;
-}
-
-tbody > tr:last-child > th.govuk-table__cell--no-line {
-  border-bottom-style: solid!important;
-}
-
-tbody > tr:last-child > td.govuk-table__cell--no-line{
-  border-bottom-style: solid!important;
-}
-
-
-
-
-

--- a/src/main/assets/scss/main.scss
+++ b/src/main/assets/scss/main.scss
@@ -5,6 +5,27 @@
   padding: 1vh 0 0;
 }
 
+.govuk-table__cell--no-line {
+  @extend .govuk-table__cell;
+  border-style: hidden;
+  font-weight: inherit;
+}
+
+tbody > tr:first-child > th.govuk-table__cell--no-line{
+  border-style: inherit!important;
+}
+tbody > tr:first-child > td.govuk-table__cell--no-line{
+  border-top: 1px solid $govuk-border-colour !important;
+}
+
+tbody > tr:last-child > th.govuk-table__cell--no-line {
+  border-bottom-style: solid!important;
+}
+
+tbody > tr:last-child > td.govuk-table__cell--no-line{
+  border-bottom-style: solid!important;
+}
+
 
 
 

--- a/src/main/controllers/SearchResultsController.ts
+++ b/src/main/controllers/SearchResultsController.ts
@@ -1,0 +1,18 @@
+import { Response } from 'express';
+import { InputFilterService} from '../service/inputFilterService';
+
+const inputFilterService = new InputFilterService();
+const searchAgainst = ['name', 'jurisdiction', 'location'];
+
+export default class SearchResultsController {
+  public get(req: Request, res: Response): void {
+    const searchInput = req.body['search-input'];
+    const searchResults = inputFilterService.findCourts(searchInput, searchAgainst);
+
+    if (searchResults.length > 0) {
+      res.render('search-results', {searchInput, searchResults});
+    } else {
+      res.render('error');
+    }
+  }
+}

--- a/src/main/modules/awilix/index.ts
+++ b/src/main/modules/awilix/index.ts
@@ -8,7 +8,7 @@ const logger = Logger.getLogger('app');
 
 export class Container {
 
-  public enableFor(app: Application) {
+  public enableFor(app: Application): void {
     const jsonObject = {};
     const files = fs.readdirSync(path.join(__dirname, '../../controllers'));
     files.forEach((f) => {

--- a/src/main/resources/mocks/courtsAndHearingsCount.json
+++ b/src/main/resources/mocks/courtsAndHearingsCount.json
@@ -3,501 +3,701 @@
     {
       "courtId": 1,
       "name": "Mutsu Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 10
     },
     {
       "courtId": 2,
       "name": "Khvalynsk Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 9
     },
     {
       "courtId": 3,
       "name": "Saint-Sauveur Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 0
     },
     {
       "courtId": 4,
       "name": "Dushu Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 2
     },
     {
       "courtId": 5,
       "name": "Girijaya Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 8
     },
     {
       "courtId": 6,
       "name": "Palma De Mallorca Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 0
     },
     {
       "courtId": 7,
       "name": "Kahnūj Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 8
     },
     {
       "courtId": 8,
       "name": "Bodega Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 6
     },
     {
       "courtId": 9,
       "name": "Narva Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 8
     },
     {
       "courtId": 10,
       "name": "Polzela Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 2
     },
     {
       "courtId": 11,
       "name": "Cristalina Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 6
     },
     {
       "courtId": 12,
       "name": "Shar Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 7
     },
     {
       "courtId": 13,
       "name": "Gniezno Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 3
     },
     {
       "courtId": 14,
       "name": "Doncaster Crown Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 1
     },
     {
       "courtId": 15,
       "name": "Lom Sak Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 1
     },
     {
       "courtId": 16,
       "name": "Mayapusi Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 7
     },
     {
       "courtId": 17,
       "name": "Mogilany Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 5
     },
     {
       "courtId": 18,
       "name": "Daveluyville Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 4
     },
     {
       "courtId": 19,
       "name": "Tadmur Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 6
     },
     {
       "courtId": 20,
       "name": "Trzciana Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 10
     },
     {
       "courtId": 21,
       "name": "Pittsburgh Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 9
     },
     {
       "courtId": 43,
       "name": "Nice Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 7
     },
     {
       "courtId": 22,
       "name": "Lisala Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 8
     },
     {
       "courtId": 23,
       "name": "Sidi Slimane Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 6
     },
     {
       "courtId": 24,
       "name": "Kluki Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 0
     },
     {
       "courtId": 25,
       "name": "Jincheng Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 2
     },
     {
       "courtId": 30,
       "name": "Salogon Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 5
     },
     {
       "courtId": 27,
       "name": "Vaiamonte Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 9
     },
     {
       "courtId": 26,
       "name": "Albertville Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 10
     },
     {
       "courtId": 28,
       "name": "Granja Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 8
     },
     {
       "courtId": 29,
       "name": "Ponoka Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 6
     },
     {
       "courtId": 31,
       "name": "Lyon Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 3
     },
     {
       "courtId": 33,
       "name": "Da-an Sur Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 2
     },
     {
       "courtId": 32,
       "name": "Aylesbury Magistrate's Court",
+      "jurisdiction": "Crown Court",
+      "location": "Aylesbury",
       "hearings": 6
     },
     {
       "courtId": 34,
       "name": "Aylesbury Crown Court",
+      "jurisdiction": "Crown Court",
+      "location": "Aylesbury",
       "hearings": 8
     },
     {
       "courtId": 35,
       "name": "Baizhu Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 5
     },
     {
       "courtId": 36,
       "name": "Birmigham Magistrate's Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 2
     },
     {
       "courtId": 37,
       "name": "Lingshan Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 1
     },
     {
       "courtId": 38,
       "name": "Quanshang Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 8
     },
     {
       "courtId": 39,
       "name": "Mosetse Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 2
     },
     {
       "courtId": 40,
       "name": "Batibati Court",
+      "jurisdiction": "Crown Court",
+      "location": "Birmingham",
       "hearings": 4
     },
     {
       "courtId": 49,
       "name": "Zaton Court",
+      "jurisdiction": "Crown Court",
+      "location": "Birmingham",
       "hearings": 6
     },
     {
       "courtId": 41,
       "name": "Nanto-shi Court",
+      "jurisdiction": "Crown Court",
+      "location": "Birmingham",
       "hearings": 2
     },
     {
       "courtId": 42,
       "name": "Zaragoza Court",
+      "jurisdiction": "Crown Court",
+      "location": "Birmingham",
       "hearings": 2
     },
     {
       "courtId": 44,
       "name": "Rengat Court",
+      "jurisdiction": "Crown Court",
+      "location": "Birmingham",
       "hearings": 1
     },
     {
       "courtId": 45,
       "name": "Bedford Crown Court",
+      "jurisdiction": "Crown Court",
+      "location": "Birmingham",
       "hearings": 10
     },
     {
       "courtId": 55,
       "name": "Sugihwaras Court",
+      "jurisdiction": "Magistrates Court",
+      "location": "Birmingham",
       "hearings": 8
     },
     {
       "courtId": 50,
       "name": "Sawara Court",
+      "jurisdiction": "Magistrates Court",
+      "location": "Birmingham",
       "hearings": 5
     },
     {
       "courtId": 46,
       "name": "Changning Court",
+      "jurisdiction": "Magistrates Court",
+      "location": "Birmingham",
       "hearings": 7
     },
     {
       "courtId": 47,
       "name": "Luzhany Court",
+      "jurisdiction": "Magistrates Court",
+      "location": "Birmingham",
       "hearings": 2
     },
     {
       "courtId": 48,
       "name": "Mashiko Court",
+      "jurisdiction": "Magistrates Court",
+      "location": "Birmingham",
       "hearings": 7
     },
     {
       "courtId": 51,
       "name": "Birmingham Crown Court",
+      "jurisdiction": "Magistrates Court",
+      "location": "Birmingham",
       "hearings": 5
     },
     {
       "courtId": 52,
       "name": "Frydrychowice Court",
+      "jurisdiction": "Magistrates Court",
+      "location": "Birmingham",
       "hearings": 7
     },
     {
       "courtId": 53,
       "name": "Chengnan Court",
+      "jurisdiction": "Magistrates Court",
+      "location": "Birmingham",
       "hearings": 9
     },
     {
       "courtId": 54,
       "name": "København Court",
+      "jurisdiction": "Magistrates Court",
+      "location": "Birmingham",
       "hearings": 3
     },
     {
       "courtId": 56,
       "name": "Libog Court",
+      "jurisdiction": "Magistrates Court",
+      "location": "Birmingham",
       "hearings": 9
     },
     {
       "courtId": 57,
       "name": "Jianxin Court",
+      "jurisdiction": "Magistrates Court",
+      "location": "Birmingham",
       "hearings": 8
     },
     {
       "courtId": 59,
       "name": "Ciladaeun Court",
+      "jurisdiction": "Magistrates Court",
+      "location": "Birmingham",
       "hearings": 4
     },
     {
       "courtId": 58,
       "name": "Jingguan Court",
+      "jurisdiction": "Magistrates Court",
+      "location": "Birmingham",
       "hearings": 7
     },
     {
       "courtId": 60,
       "name": "Qigzhi Court",
+      "jurisdiction": "Magistrates Court",
+      "location": "Birmingham",
       "hearings": 1
     },
     {
       "courtId": 61,
       "name": "Loma Court",
+      "jurisdiction": "Magistrates Court",
+      "location": "Birmingham",
       "hearings": 5
     },
     {
       "courtId": 62,
       "name": "Crewe Crown Court",
+      "jurisdiction": "Magistrates Court",
+      "location": "Birmingham",
       "hearings": 0
     },
     {
       "courtId": 63,
       "name": "Kuala Lumpur Court",
+      "jurisdiction": "Magistrates Court",
+      "location": "London",
       "hearings": 8
     },
     {
       "courtId": 70,
       "name": "Xiangqiao Court",
+      "jurisdiction": "Magistrates Court",
+      "location": "London",
       "hearings": 2
     },
     {
       "courtId": 69,
       "name": "Villa Bisonó Court",
+      "jurisdiction": "Magistrates Court",
+      "location": "London",
       "hearings": 5
     },
     {
       "courtId": 64,
       "name": "Jiufeng Court",
+      "jurisdiction": "Magistrates Court",
+      "location": "London",
       "hearings": 1
     },
     {
       "courtId": 65,
       "name": "Peraía Court",
+      "jurisdiction": "Magistrates Court",
+      "location": "London",
       "hearings": 10
     },
     {
       "courtId": 66,
       "name": "Novhorod-Sivers’kyy Court",
+      "jurisdiction": "Magistrates Court",
+      "location": "London",
       "hearings": 7
     },
     {
       "courtId": 67,
       "name": "Vargem Grande Court",
+      "jurisdiction": "Magistrates Court",
+      "location": "London",
       "hearings": 3
     },
     {
       "courtId": 68,
       "name": "Chernyshevsk Court",
+      "jurisdiction": "Magistrates Court",
+      "location": "London",
       "hearings": 8
     },
     {
       "courtId": 71,
       "name": "Carig Court",
+      "jurisdiction": "Magistrates Court",
+      "location": "London",
       "hearings": 9
     },
     {
       "courtId": 72,
       "name": "Cardiff Magistrate's Court",
+      "jurisdiction": "Magistrates Court",
+      "location": "London",
       "hearings": 1
     },
     {
       "courtId": 73,
       "name": "Gangkoujie Court",
+      "jurisdiction": "Magistrates Court",
+      "location": "London",
       "hearings": 4
     },
     {
       "courtId": 81,
       "name": "Huacao Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 10
     },
     {
       "courtId": 74,
       "name": "Bobai Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 6
     },
     {
       "courtId": 76,
       "name": "Trnovska Vas Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 9
     },
     {
       "courtId": 75,
       "name": "Manga Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 3
     },
     {
       "courtId": 77,
       "name": "Dauriya Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 2
     },
     {
       "courtId": 78,
       "name": "Houyu Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 2
     },
     {
       "courtId": 79,
       "name": "Exter Magistrate's Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 10
     },
     {
       "courtId": 80,
       "name": "Giraldo Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 10
     },
     {
       "courtId": 82,
       "name": "Lilongwe Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 10
     },
     {
       "courtId": 83,
       "name": "Paris Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 7
     },
     {
       "courtId": 84,
       "name": "Sulahan Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 7
     },
     {
       "courtId": 85,
       "name": "Magisterial Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 4
     },
     {
       "courtId": 86,
       "name": "Kyperoúnta Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 0
     },
     {
       "courtId": 87,
       "name": "Dallas Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 3
     },
     {
       "courtId": 88,
       "name": "Ailibugai Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 0
     },
     {
       "courtId": 89,
       "name": "Portela Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 5
     },
     {
       "courtId": 90,
       "name": "Metallostroy Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 8
     },
     {
       "courtId": 91,
       "name": "Kurikka Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 7
     },
     {
       "courtId": 97,
       "name": "Upton Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 0
     },
     {
       "courtId": 92,
       "name": "Sanxi Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 3
     },
     {
       "courtId": 94,
       "name": "El Hermel Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 8
     },
     {
       "courtId": 93,
       "name": "Pinillos Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 0
     },
     {
       "courtId": 95,
       "name": "Kaoshan Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 1
     },
     {
       "courtId": 96,
       "name": "Kodamachō-kodamaminami Court",
+      "jurisdiction": "Crown Court",
+      "location": "London",
       "hearings": 5
     },
     {
       "courtId": 98,
       "name": "Sigli Court",
+      "jurisdiction": "Crown Court",
+      "location": "Leeds",
       "hearings": 2
     },
     {
       "courtId": 99,
       "name": "Padova Court",
+      "jurisdiction": "Crown Court",
+      "location": "Leeds",
       "hearings": 9
     },
     {
       "courtId": 100,
       "name": "Qiqing Court",
+      "jurisdiction": "Crown Court",
+      "location": "Leeds",
       "hearings": 2
     }
   ]

--- a/src/main/routes/routes.ts
+++ b/src/main/routes/routes.ts
@@ -17,5 +17,6 @@ export default function(app: Application): void {
       // TODO: add downstream info endpoints if your app has any
     },
   }));
+  app.get('/search-results', app.locals.container.cradle.searchResultsController.get);
 
 }

--- a/src/main/routes/routes.ts
+++ b/src/main/routes/routes.ts
@@ -1,6 +1,6 @@
 import { Application } from 'express';
 import {infoRequestHandler} from '@hmcts/info-provider';
-import os from "os";
+import os from 'os';
 
 export default function(app: Application): void {
 

--- a/src/main/service/inputFilterService.ts
+++ b/src/main/service/inputFilterService.ts
@@ -1,0 +1,28 @@
+import { CourtActions } from '../resources/actions/courtActions';
+import { JSONArray } from 'puppeteer';
+
+const courtActions = new CourtActions();
+let courtsResults;
+let searchResults;
+
+export class InputFilterService {
+  public findCourts(searchInput, checkAgainst): JSONArray {
+    searchResults = [];
+    if (!this.checkNotNullOrEmpty(searchInput)) {
+      return searchResults;
+    }
+    courtsResults = courtActions.getCourtsList();
+    checkAgainst.forEach(item => {
+      this.checkInputAgainstSearchValue(searchInput, item);
+    });
+    return searchResults;
+  }
+
+  private checkNotNullOrEmpty(value): boolean {
+    return value != undefined || value != '';
+  }
+
+  private checkInputAgainstSearchValue(searchInput, item) {
+    courtsResults.filter(i => i[item] === searchInput).forEach(result => searchResults.push(result));
+  }
+}

--- a/src/main/service/inputFilterService.ts
+++ b/src/main/service/inputFilterService.ts
@@ -22,7 +22,7 @@ export class InputFilterService {
     return value != undefined || value != '';
   }
 
-  private checkInputAgainstSearchValue(searchInput, item) {
+  private checkInputAgainstSearchValue(searchInput, item): void {
     courtsResults.filter(i => i[item] === searchInput).forEach(result => searchResults.push(result));
   }
 

--- a/src/main/service/inputFilterService.ts
+++ b/src/main/service/inputFilterService.ts
@@ -15,7 +15,7 @@ export class InputFilterService {
     checkAgainst.forEach(item => {
       this.checkInputAgainstSearchValue(searchInput, item);
     });
-    return searchResults;
+    return this.alphabetiseResults(searchResults, 'name');
   }
 
   private checkNotNullOrEmpty(value): boolean {
@@ -24,5 +24,9 @@ export class InputFilterService {
 
   private checkInputAgainstSearchValue(searchInput, item) {
     courtsResults.filter(i => i[item] === searchInput).forEach(result => searchResults.push(result));
+  }
+
+  public alphabetiseResults(unsortedArray: JSONArray, leadValue): JSONArray {
+    return unsortedArray.sort((a, b) => a[leadValue].localeCompare(b[leadValue]));
   }
 }

--- a/src/main/views/search-results.njk
+++ b/src/main/views/search-results.njk
@@ -1,0 +1,38 @@
+{% extends "template.njk" %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/table/macro.njk" import govukTable %}
+
+{% block pageTitle %}
+  {{ "Search Results" | safe }}
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "/search-option"
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <h1 class="govuk-heading-l">Courts or tribunals in {{ searchInput }}</h1>
+  <p class="govuk-body">We have found {{ searchResults.length }} courts or tribunals matching your search for
+    '{{ searchInput }}'</p>
+
+  <table class="govuk-table govuk-!-width-two-thirds">
+    <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header">Court or tribunal</th>
+      <th scope="col" class="govuk-table__header--numeric">Number of hearings</th>
+    </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+    {% for result in searchResults %}
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__cell--no-line govuk-link"><a href="/hearing-list?courtId={{ result.courtId }}">{{ result.name }}</a></th>
+        <td class="govuk-table__cell--no-line govuk-table__cell--numeric">{{ result.hearings }}</td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+
+{% endblock %}

--- a/src/main/views/search-results.njk
+++ b/src/main/views/search-results.njk
@@ -28,7 +28,7 @@
     <tbody class="govuk-table__body">
     {% for result in searchResults %}
       <tr class="govuk-table__row">
-        <th scope="row" class="govuk-table__cell--no-line govuk-link"><a href="/hearing-list?courtId={{ result.courtId }}">{{ result.name }}</a></th>
+        <th scope="row" class="govuk-table__cell--no-line"><a class="govuk-link" href="/hearing-list?courtId={{ result.courtId }}">{{ result.name }}</a></th>
         <td class="govuk-table__cell--no-line govuk-table__cell--numeric">{{ result.hearings }}</td>
       </tr>
     {% endfor %}

--- a/src/test/routes/search-results.test.ts
+++ b/src/test/routes/search-results.test.ts
@@ -1,0 +1,15 @@
+import { expect } from 'chai';
+import request from 'supertest';
+
+import { app } from '../../main/app';
+
+
+describe('Search results', () => {
+  describe('on GET', () => {
+    test('should return search results page', async () => {
+      await request(app)
+        .get('/search-results')
+        .expect((res) => expect(res.status).to.equal(200));
+    });
+  });
+});

--- a/src/test/unit/controllers/SearchResultsController.test.ts
+++ b/src/test/unit/controllers/SearchResultsController.test.ts
@@ -1,0 +1,35 @@
+import SearchResultsController from '../../../main/controllers/SearchResultsController';
+import sinon from 'sinon';
+import { Response } from 'express';
+
+describe('Search results Controller', () => {
+  it('should render the search results page if input is valid', () =>  {
+    const searchResultsController = new SearchResultsController();
+
+    const response = { render: function() {return '';}} as unknown as Response;
+    const request = {body: {'search-input': 'Aylesbury'}} as unknown as Request;
+
+    const responseMock = sinon.mock(response);
+
+    responseMock.expects('render').once().withArgs('search-results');
+
+    searchResultsController.get(request, response);
+
+    responseMock.verify();
+  });
+
+  it('should render an error page if search input does not return any results', () =>  {
+    const searchResultsController = new SearchResultsController();
+
+    const response = { render: function() {return '';}} as unknown as Response;
+    const request = { body: { 'search-input': ''}} as unknown as Request;
+
+    const responseMock = sinon.mock(response);
+
+    responseMock.expects('render').once().withArgs('error');
+
+    searchResultsController.get(request, response);
+
+    responseMock.verify();
+  });
+});

--- a/src/test/unit/service/inputFilterService.test.ts
+++ b/src/test/unit/service/inputFilterService.test.ts
@@ -1,0 +1,62 @@
+import {InputFilterService} from '../../../main/service/inputFilterService';
+import {expect} from 'chai';
+
+const inputService = new InputFilterService();
+
+const validSearchInputName = 'Aylesbury Magistrate\'s Court';
+const validSearchInputLocation = 'Aylesbury';
+const validSearchInputJurisdiction = 'Magistrates Court';
+const validCheckAgainst = ['name', 'location', 'jurisdiction'];
+
+const invalidSearchInputEmpty = '';
+const invalidSearchInputUndefined = undefined;
+
+const expectedResultFromName = [{
+  courtId: 32,
+  name: 'Aylesbury Magistrate\'s Court',
+  jurisdiction: 'Crown Court',
+  location: 'Aylesbury',
+  hearings: 6,
+}];
+
+const expectedResultFromLocation = [
+  {
+    courtId: 32,
+    name: 'Aylesbury Magistrate\'s Court',
+    jurisdiction: 'Crown Court',
+    location: 'Aylesbury',
+    hearings: 6,
+  },
+  {
+    courtId: 34,
+    name: 'Aylesbury Crown Court',
+    jurisdiction: 'Crown Court',
+    location: 'Aylesbury',
+    hearings: 8,
+  }];
+
+describe('Input filter service', () => {
+  it('should return filtered list with 1 match', () => {
+    expect(inputService.findCourts(validSearchInputName, validCheckAgainst)).to.deep.equal(expectedResultFromName, 'Result did not match expected');
+  });
+
+  it('should return filtered list with 1 check against', () => {
+    expect(inputService.findCourts(validSearchInputName, ['name'])).to.deep.equal(expectedResultFromName, 'Result did not match expected');
+  });
+
+  it('should return filtered list with 2 matches', () => {
+    expect(inputService.findCourts(validSearchInputLocation, validCheckAgainst)).to.deep.equal(expectedResultFromLocation, 'Result did not match expected');
+  });
+
+  it('should return filtered list with matches', () => {
+    expect(inputService.findCourts(validSearchInputJurisdiction, validCheckAgainst).length).equal(27, 'Results length did not match expected');
+  });
+
+  it('should return empty array for empty search input', () => {
+    expect(inputService.findCourts(invalidSearchInputEmpty, validCheckAgainst).length).equal(0, 'No results should be returned');
+  });
+
+  it('should return empty array for undefined search input', () => {
+    expect(inputService.findCourts(invalidSearchInputUndefined, validCheckAgainst).length).equal(0, 'No results should be returned');
+  });
+});

--- a/src/test/unit/service/inputFilterService.test.ts
+++ b/src/test/unit/service/inputFilterService.test.ts
@@ -21,18 +21,18 @@ const expectedResultFromName = [{
 
 const expectedResultFromLocation = [
   {
-    courtId: 32,
-    name: 'Aylesbury Magistrate\'s Court',
-    jurisdiction: 'Crown Court',
-    location: 'Aylesbury',
-    hearings: 6,
-  },
-  {
     courtId: 34,
     name: 'Aylesbury Crown Court',
     jurisdiction: 'Crown Court',
     location: 'Aylesbury',
     hearings: 8,
+  },
+  {
+    courtId: 32,
+    name: 'Aylesbury Magistrate\'s Court',
+    jurisdiction: 'Crown Court',
+    location: 'Aylesbury',
+    hearings: 6,
   }];
 
 describe('Input filter service', () => {
@@ -58,5 +58,24 @@ describe('Input filter service', () => {
 
   it('should return empty array for undefined search input', () => {
     expect(inputService.findCourts(invalidSearchInputUndefined, validCheckAgainst).length).equal(0, 'No results should be returned');
+  });
+
+  it('should alphabetise an unsorted array', () => {
+    const unsorted = [
+      {
+        courtId: 34,
+        name: 'Zenon Court',
+        jurisdiction: 'Crown Court',
+        location: 'Aylesbury',
+        hearings: 8,
+      },
+      {
+        courtId: 32,
+        name: 'Aylesbury Magistrate\'s Court',
+        jurisdiction: 'Crown Court',
+        location: 'Aylesbury',
+        hearings: 6,
+      }];
+    expect(inputService.alphabetiseResults(unsorted, 'name')[0]['name']).equal('Aylesbury Magistrate\'s Court', 'List was not sorted alphabetically correctly');
   });
 });

--- a/src/test/unit/views/search-results.test.ts
+++ b/src/test/unit/views/search-results.test.ts
@@ -1,0 +1,67 @@
+import {expect} from 'chai';
+import request from 'supertest';
+
+import {app} from '../../../main/app';
+
+const PAGE_URL = '/search-results';
+const searchTerm = 'Aylesbury';
+const numOfResults = '2';
+
+const rowClass = 'govuk-table__row';
+
+let htmlRes: Document;
+
+describe('Search Results Page', () => {
+  beforeAll(async () => {
+    const payload = {'search-input': searchTerm};
+    await request(app).get(PAGE_URL).send(payload).then(res => {
+      htmlRes = new DOMParser().parseFromString(res.text, 'text/html');
+    });
+  });
+
+  it('should display back button', () => {
+    const backButton = htmlRes.getElementsByClassName('govuk-back-link');
+    expect(backButton[0].innerHTML).contains('Back', 'Back button does not contain correct text');
+    expect(backButton[0].getAttribute('href')).equal('/search-option', 'Back button does not contain correct link');
+  });
+
+  it('should display search term in header', () => {
+    const header = htmlRes.getElementsByClassName('govuk-heading-l');
+    expect(header[0].innerHTML).contains(searchTerm, 'Could not find search term in header');
+  });
+
+  it('should list the number of results found', () => {
+    const bodyText = htmlRes.getElementsByClassName('govuk-body');
+    expect(bodyText[0].innerHTML).contains(numOfResults, `Could not find ${numOfResults} results in the body`);
+  });
+
+  it('should display first table header', () => {
+    const tableHeader1 = htmlRes.getElementsByClassName('govuk-table__header');
+    expect(tableHeader1[0].innerHTML).contains('Court or tribunal', 'Could not find text in first header');
+  });
+
+  it('should display second table header', () => {
+    const tableHeader2 = htmlRes.getElementsByClassName('govuk-table__header--numeric');
+    expect(tableHeader2[0].innerHTML).contains('Number of hearings', 'Could not find text in second header');
+  });
+
+  it('should contain 3 rows including the header row', () => {
+    const rows = htmlRes.getElementsByClassName(rowClass);
+    expect(rows.length).equal(3, 'Table did not contain expected number of rows');
+  });
+
+  it('should contain rows with correct values', () => {
+    const rows = htmlRes.getElementsByClassName(rowClass);
+    const items = rows.item(1).children;
+
+    expect(items[0].innerHTML).contains('Aylesbury Magistrate\'s Court', 'First court not listed correctly');
+    expect(items[1].innerHTML).contains('6', 'First court has incorrect number of hearings');
+  });
+
+  it('should contain correct link in search result', () => {
+    const rows = htmlRes.getElementsByClassName(rowClass);
+    const items = rows.item(1).children;
+
+    expect(items[0].children[0].getAttribute('href')).equal('/hearing-list?courtId=32', 'First court not listed correctly');
+  });
+});

--- a/src/test/unit/views/search-results.test.ts
+++ b/src/test/unit/views/search-results.test.ts
@@ -54,14 +54,14 @@ describe('Search Results Page', () => {
     const rows = htmlRes.getElementsByClassName(rowClass);
     const items = rows.item(1).children;
 
-    expect(items[0].innerHTML).contains('Aylesbury Magistrate\'s Court', 'First court not listed correctly');
-    expect(items[1].innerHTML).contains('6', 'First court has incorrect number of hearings');
+    expect(items[0].innerHTML).contains('Aylesbury Crown Court', 'First court not listed correctly');
+    expect(items[1].innerHTML).contains('8', 'First court has incorrect number of hearings');
   });
 
   it('should contain correct link in search result', () => {
     const rows = htmlRes.getElementsByClassName(rowClass);
     const items = rows.item(1).children;
 
-    expect(items[0].children[0].getAttribute('href')).equal('/hearing-list?courtId=32', 'First court not listed correctly');
+    expect(items[0].children[0].getAttribute('href')).equal('/hearing-list?courtId=34', 'First court not listed correctly');
   });
 });


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link ###
https://tools.hmcts.net/jira/browse/PUB-508


### Change description ###
## Added
new nunjucks file to display search results
controller for search results
service directory that contains a input filter to check inputs for searching against values in the json data

tests 

## Changed/updated
updated json mock data for courts to include `location` and `jurisdiction` as values that can searched against
updated main.scss to add class that allows table to be used without the cell lines
updated and extended gov class to make the first and last cell display lines

Added new nunjucks file for displaying the search results, added to the main.scss to modify table cell classes for first and last to display lines and created new class to remove lines for others,

### NOTE
not linked yet, blocked through 506

## screenshot
<img width="959" alt="Screenshot 2021-08-04 at 14 30 44" src="https://user-images.githubusercontent.com/26488566/128189579-0e424750-62a5-4fa0-9713-89ae082d2749.png">



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
