### PR TITLE
PUB-693 - OTP Success Path UI

### DIFF
--- a/src/main/controllers/OtpLoginController.ts
+++ b/src/main/controllers/OtpLoginController.ts
@@ -1,0 +1,17 @@
+import { Request, Response } from 'express';
+
+export default class OtpLoginController {
+  public get(req: Request, res: Response): void {
+      res.render('otp-login');
+  }
+
+  public post(req: Request, res: Response): void {
+    if (req.body['otp-code'].length === 6) {
+      res.redirect('subscription-management')
+    } else {
+      res.redirect('otp-login')
+    }
+
+  }
+
+}

--- a/src/main/controllers/OtpLoginController.ts
+++ b/src/main/controllers/OtpLoginController.ts
@@ -2,14 +2,14 @@ import { Request, Response } from 'express';
 
 export default class OtpLoginController {
   public get(req: Request, res: Response): void {
-      res.render('otp-login');
+    res.render('otp-login');
   }
 
   public post(req: Request, res: Response): void {
-    if (req.body['otp-code'].length === 6) {
-      res.redirect('subscription-management')
+    if (req.body['otp-code'] !== undefined && req.body['otp-code'].length === 6) {
+      res.redirect('subscription-management');
     } else {
-      res.redirect('otp-login')
+      res.redirect('otp-login');
     }
 
   }

--- a/src/main/controllers/OtpLoginController.ts
+++ b/src/main/controllers/OtpLoginController.ts
@@ -6,7 +6,7 @@ export default class OtpLoginController {
   }
 
   public post(req: Request, res: Response): void {
-    if (req.body['otp-code'] !== undefined && req.body['otp-code'].length === 6) {
+    if (req.body['otp-code'] && req.body['otp-code'].length === 6) {
       res.redirect('subscription-management');
     } else {
       res.redirect('otp-login');

--- a/src/main/controllers/SubscriptionManagementController.ts
+++ b/src/main/controllers/SubscriptionManagementController.ts
@@ -2,6 +2,6 @@ import { Request, Response } from 'express';
 
 export default class SubscriptionManagementController {
   public get(req: Request, res: Response): void {
-      res.render('subscription-management');
+    res.render('subscription-management');
   }
 }

--- a/src/main/controllers/SubscriptionManagementController.ts
+++ b/src/main/controllers/SubscriptionManagementController.ts
@@ -1,0 +1,7 @@
+import { Request, Response } from 'express';
+
+export default class SubscriptionManagementController {
+  public get(req: Request, res: Response): void {
+      res.render('subscription-management');
+  }
+}

--- a/src/main/routes/routes.ts
+++ b/src/main/routes/routes.ts
@@ -12,6 +12,8 @@ export default function(app: Application): void {
   app.get('/alphabetical-search', app.locals.container.cradle.alphabeticalSearchController.get);
   app.get('/hearing-list', app.locals.container.cradle.hearingListController.get);
   app.get('/not-found', app.locals.container.cradle.notFoundPageController.get);
+  app.get('/otp-login', app.locals.container.cradle.otpLoginController.get);
+  app.post('/otp-login', app.locals.container.cradle.otpLoginController.post);
   app.get('/info', infoRequestHandler({
     extraBuildInfo: {
       host: os.hostname(),
@@ -27,6 +29,8 @@ export default function(app: Application): void {
 
   app.post('/search-option', app.locals.container.cradle.searchOptionController.post);
   app.post('/search', app.locals.container.cradle.searchController.post);
+
+  app.get('/subscription-management', app.locals.container.cradle.subscriptionManagementController.get);
 
   const healthCheckConfig = {
     checks: {

--- a/src/main/views/otp-login.njk
+++ b/src/main/views/otp-login.njk
@@ -1,0 +1,42 @@
+{% from "./macros/common-components.njk" import goBack %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% extends "template.njk" %}
+{% block pageTitle %}
+  {{ "OTP Login" | safe }}
+{% endblock %}
+{% block content %}
+  <form method="post" novalidate>
+    <h1 class="govuk-heading-l govuk-!-margin-top-5">Verify your email address</h1>
+    <h3 class="govuk-heading-s">Enter your 6-digit passcode</h3>
+    <div>
+      <input class="govuk-input
+      govuk-input--width-10
+      govuk-!-margin-right-2" id="otp-code" name="otp-code"
+             inputmode="numeric"
+             type="number"
+             pattern='[0-9]*'
+             oninput="
+             if (this.value.length > 6) {
+              this.value = this.value.slice(0,6);
+             }">
+
+      <span class="govuk-body">You have 3 attempts</span>
+    </div>
+
+    {{ govukButton({
+      text: "Continue",
+      classes: "govuk-!-margin-top-5 govuk-!-margin-bottom-8"
+
+    }) }}
+
+  </form>
+  <div class="govuk-body">If you have entered an incorrect passcode,
+    request to have a new passcode sent to your email address</div>
+
+  {{ govukButton({
+    text: "Resend passcode",
+    classes: "govuk-button--secondary govuk-!-margin-bottom-9"
+  }) }}
+
+{% endblock %}

--- a/src/main/views/otp-login.njk
+++ b/src/main/views/otp-login.njk
@@ -8,7 +8,7 @@
 {% block content %}
   <form method="post" novalidate>
     <h1 class="govuk-heading-l govuk-!-margin-top-5">Verify your email address</h1>
-    <h3 class="govuk-heading-s">Enter your 6-digit passcode</h3>
+    <h3 class="govuk-heading-s" id="input-label">Enter your 6-digit passcode</h3>
     <div>
       <input class="govuk-input
       govuk-input--width-10
@@ -16,6 +16,7 @@
              inputmode="numeric"
              type="number"
              pattern='[0-9]*'
+             aria-labelledby="input-label"
              oninput="
              if (this.value.length > 6) {
               this.value = this.value.slice(0,6);

--- a/src/main/views/subscription-management.njk
+++ b/src/main/views/subscription-management.njk
@@ -1,0 +1,10 @@
+{% from "./macros/common-components.njk" import goBack %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% extends "template.njk" %}
+{% block pageTitle %}
+  {{ "Subscription Management" | safe }}
+{% endblock %}
+{% block content %}
+  <h1 class="govuk-heading-l">Subscription Management</h1>
+{% endblock %}

--- a/src/test/e2e/Helpers/Selectors.ts
+++ b/src/test/e2e/Helpers/Selectors.ts
@@ -29,4 +29,7 @@ module.exports = {
   },
   FirstItemResult: 'tbody > tr.govuk-table__row > td > div > a',
 
+  // OtpLogin page selectors
+  OtpInput: '#otp-code'
+
 };

--- a/src/test/e2e/Helpers/Selectors.ts
+++ b/src/test/e2e/Helpers/Selectors.ts
@@ -30,6 +30,6 @@ module.exports = {
   FirstItemResult: 'tbody > tr.govuk-table__row > td > div > a',
 
   // OtpLogin page selectors
-  OtpInput: '#otp-code'
+  OtpInput: '#otp-code',
 
 };

--- a/src/test/e2e/PageObjects/OtpLoginPage.po.ts
+++ b/src/test/e2e/PageObjects/OtpLoginPage.po.ts
@@ -1,0 +1,42 @@
+import { SubscriptionManagementPo } from './SubscriptionManagement.po';
+import {Page} from 'puppeteer';
+
+const helpers = require('../Helpers/Selectors');
+const config = require('../../../../jest.config.e2e');
+
+let page: Page;
+
+export class OtpLoginPagePo {
+  async OpenOtpLoginPage(_page: Page): Promise<any> {
+    page = _page;
+    await page.goto(config.globals.URL + "/otp-login", {waitUntil: 'domcontentloaded'});
+    return page;
+  }
+
+  async getPageTitle(): Promise<string> {
+    await page.waitForSelector(helpers.CommonPageTitle).catch(() => {
+      console.log(`${helpers.CommonPageTitle} not found`);
+    });
+
+    return await page.$eval(helpers.CommonPageTitle, (e: Element) => e.textContent);
+  }
+
+  async enterText(text: string): Promise<void> {
+    await page.waitForSelector(helpers.OtpInput).catch(() => {
+      console.log(`${helpers.OtpInput} not found`);
+    });
+
+    await page.type(helpers.OtpInput, text);
+    await page.keyboard.press('Escape');
+  }
+
+  async clickContinue(): Promise<SubscriptionManagementPo> {
+    await page.waitForSelector(helpers.ContinueButton).catch(() => {
+      console.log(`${helpers.ContinueButton} not found`);
+    });
+
+    await page.click(helpers.ContinueButton);
+
+    return new SubscriptionManagementPo(page);
+  }
+}

--- a/src/test/e2e/PageObjects/OtpLoginPage.po.ts
+++ b/src/test/e2e/PageObjects/OtpLoginPage.po.ts
@@ -9,7 +9,7 @@ let page: Page;
 export class OtpLoginPagePo {
   async OpenOtpLoginPage(_page: Page): Promise<any> {
     page = _page;
-    await page.goto(config.globals.URL + "/otp-login", {waitUntil: 'domcontentloaded'});
+    await page.goto(config.globals.URL + '/otp-login', {waitUntil: 'domcontentloaded'});
     return page;
   }
 

--- a/src/test/e2e/PageObjects/SubscriptionManagement.po.ts
+++ b/src/test/e2e/PageObjects/SubscriptionManagement.po.ts
@@ -1,4 +1,4 @@
-import {Page} from "puppeteer";
+import {Page} from 'puppeteer';
 const helpers = require('../Helpers/Selectors');
 
 let page: Page;

--- a/src/test/e2e/PageObjects/SubscriptionManagement.po.ts
+++ b/src/test/e2e/PageObjects/SubscriptionManagement.po.ts
@@ -1,0 +1,21 @@
+import {Page} from "puppeteer";
+const helpers = require('../Helpers/Selectors');
+
+let page: Page;
+
+export class SubscriptionManagementPo {
+
+  constructor(_page: Page) {
+    page = _page;
+  }
+
+  async getPageTitle(): Promise<string> {
+    await page.waitForSelector(helpers.CommonPageTitle).catch(() => {
+      console.log(`${helpers.CommonPageTitle} not found`);
+    });
+
+    return await page.$eval(helpers.CommonPageTitle, (e: Element) => e.textContent);
+  }
+
+
+}

--- a/src/test/e2e/Tests/e2e.test.ts
+++ b/src/test/e2e/Tests/e2e.test.ts
@@ -18,9 +18,9 @@ let searchPage: SearchPo;
 let searchResultsPage: SearchResultsPo;
 let hearingListPage: HearingListPo;
 let alphabeticalSearchPage: AlphabeticalSearchPo;
-let subscriptionManagementPage: SubscriptionManagementPo
+let subscriptionManagementPage: SubscriptionManagementPo;
 
-let otpLoginPage = new OtpLoginPagePo;
+const otpLoginPage = new OtpLoginPagePo;
 
 let page: Page;
 let browser: Browser;
@@ -118,10 +118,10 @@ describe('Media User login', () => {
 
   it('should navigate to subscription page when correct passcode is entered', async () => {
     await otpLoginPage.enterText('222222');
-    subscriptionManagementPage = await otpLoginPage.clickContinue()
-    expect(await subscriptionManagementPage.getPageTitle()).toContain(`Subscription Management`);
+    subscriptionManagementPage = await otpLoginPage.clickContinue();
+    expect(await subscriptionManagementPage.getPageTitle()).toContain('Subscription Management');
   });
-})
+});
 
 afterAll(() => {
   browser.close();

--- a/src/test/e2e/Tests/e2e.test.ts
+++ b/src/test/e2e/Tests/e2e.test.ts
@@ -5,6 +5,8 @@ import {Page, Browser} from 'puppeteer';
 import {SearchResultsPo} from '../PageObjects/SearchResults.po';
 import {HearingListPo} from '../PageObjects/HearingList.po';
 import { AlphabeticalSearchPo } from '../PageObjects/AlphabeticalSearch.po';
+import { OtpLoginPagePo } from '../PageObjects/OtpLoginPage.po';
+import {SubscriptionManagementPo} from '../PageObjects/SubscriptionManagement.po';
 
 const puppeteerConfig = require('../../../../jest-puppeteer.config');
 const puppeteer = require('puppeteer');
@@ -16,6 +18,9 @@ let searchPage: SearchPo;
 let searchResultsPage: SearchResultsPo;
 let hearingListPage: HearingListPo;
 let alphabeticalSearchPage: AlphabeticalSearchPo;
+let subscriptionManagementPage: SubscriptionManagementPo
+
+let otpLoginPage = new OtpLoginPagePo;
 
 let page: Page;
 let browser: Browser;
@@ -104,6 +109,19 @@ describe('Finding a court or tribunal listing', () => {
     });
   });
 });
+
+describe('Media User login', () => {
+  it('should open the OTP login page', async () => {
+    await otpLoginPage.OpenOtpLoginPage(page);
+    expect(await otpLoginPage.getPageTitle()).toBe('Verify your email address');
+  });
+
+  it('should navigate to subscription page when correct passcode is entered', async () => {
+    await otpLoginPage.enterText('222222');
+    subscriptionManagementPage = await otpLoginPage.clickContinue()
+    expect(await subscriptionManagementPage.getPageTitle()).toContain(`Subscription Management`);
+  });
+})
 
 afterAll(() => {
   browser.close();

--- a/src/test/routes/otp-login.test.ts
+++ b/src/test/routes/otp-login.test.ts
@@ -1,0 +1,28 @@
+import { expect } from 'chai';
+import request from 'supertest';
+
+import { app } from '../../main/app';
+
+
+describe('Otp Login', () => {
+  describe('on GET', () => {
+    test('should return otp-login page', async () => {
+      await request(app)
+        .get('/otp-login')
+        .expect((res) => expect(res.status).to.equal(200));
+    });
+  });
+
+  describe('on POST', () => {
+    test('should return subscription management page', async () => {
+      await request(app)
+        .post('/otp-login')
+        .send({'otp-code': '123456'})
+        .expect((res) => {
+          expect(res.status).to.equal(302);
+          expect(res.header['location']).to.equal('subscription-management');
+        });
+    });
+  });
+
+});

--- a/src/test/routes/subscription-management.test.ts
+++ b/src/test/routes/subscription-management.test.ts
@@ -1,0 +1,16 @@
+import { expect } from 'chai';
+import request from 'supertest';
+
+import { app } from '../../main/app';
+
+
+describe('Subscription Management', () => {
+  describe('on GET', () => {
+    test('should return subscription-management page', async () => {
+      await request(app)
+        .get('/subscription-management')
+        .expect((res) => expect(res.status).to.equal(200));
+    });
+  });
+
+});

--- a/src/test/unit/controllers/OtpLoginController.test.ts
+++ b/src/test/unit/controllers/OtpLoginController.test.ts
@@ -1,0 +1,68 @@
+import OtpLoginController from '../../../main/controllers/OtpLoginController';
+import sinon from 'sinon';
+import { Request, Response } from 'express';
+
+describe('Otp Login Controller', () => {
+  it('should render the otp login page', () => {
+    const otpLoginController = new OtpLoginController();
+
+    const response = { render: function() {return '';}} as unknown as Response;
+    const request = {} as unknown as Request;
+
+    const responseMock = sinon.mock(response);
+
+    responseMock.expects('render').once().withArgs('otp-login');
+
+    otpLoginController.get(request, response);
+
+    responseMock.verify();
+  });
+
+
+  it('should render subscription management page if entry is 6 characters long', () => {
+    const otpLoginController = new OtpLoginController();
+
+    const response = { redirect: function() {return '';}} as unknown as Response;
+    const request = { body: { 'otp-code': '123456'}} as unknown as Request;
+
+    const responseMock = sinon.mock(response);
+
+    responseMock.expects('redirect').once().withArgs('subscription-management');
+
+    otpLoginController.post(request, response);
+
+    responseMock.verify();
+  });
+
+
+  it('should render same page if otp code is not 6 characters long', () => {
+    const otpLoginController = new OtpLoginController();
+
+    const response = { redirect: function() {return '';}} as unknown as Response;
+    const request = { body: { 'otp-login': '1234'}} as unknown as Request;
+
+    const responseMock = sinon.mock(response);
+
+    responseMock.expects('redirect').once().withArgs('otp-login');
+
+    otpLoginController.post(request, response);
+
+    responseMock.verify();
+  });
+
+  it('should render same page if no otp code is entered', () => {
+    const otpLoginController = new OtpLoginController();
+
+    const response = { redirect: function() {return '';}} as unknown as Response;
+    const request = { body: {}} as unknown as Request;
+
+    const responseMock = sinon.mock(response);
+
+    responseMock.expects('redirect').once().withArgs('otp-login');
+
+    otpLoginController.post(request, response);
+
+    responseMock.verify();
+  });
+
+});

--- a/src/test/unit/controllers/SubscriptionManagementController.test.ts
+++ b/src/test/unit/controllers/SubscriptionManagementController.test.ts
@@ -1,0 +1,21 @@
+import SubscriptionManagementController from '../../../main/controllers/SubscriptionManagementController';
+import sinon from 'sinon';
+import { Request, Response } from 'express';
+
+describe('Subscription Management Controller', () => {
+  it('should render the subscription management page', () => {
+    const subscriptionManagementController = new SubscriptionManagementController();
+
+    const response = { render: function() {return '';}} as unknown as Response;
+    const request = {} as unknown as Request;
+
+    const responseMock = sinon.mock(response);
+
+    responseMock.expects('render').once().withArgs('subscription-management');
+
+    subscriptionManagementController.get(request, response);
+
+    responseMock.verify();
+  });
+
+});

--- a/src/test/unit/views/otp-login.test.ts
+++ b/src/test/unit/views/otp-login.test.ts
@@ -1,0 +1,48 @@
+import {expect} from 'chai';
+import request from 'supertest';
+
+import {app} from '../../../main/app';
+
+const PAGE_URL = '/otp-login';
+
+const buttonClass = 'govuk-button';
+
+let htmlRes: Document;
+
+describe('Otp Login Page', () => {
+  beforeAll(async () => {
+    await request(app).get(PAGE_URL).then(res => {
+      htmlRes = new DOMParser().parseFromString(res.text, 'text/html');
+    });
+  });
+
+  it('should display header', () => {
+    const header = htmlRes.getElementsByClassName('govuk-heading-l');
+    expect(header[0].innerHTML).contains('Verify your email address', 'Could not find correct value in header');
+  });
+
+  it('should ask the user to enter the 6 digit passcode', () => {
+    const passcodeText = htmlRes.getElementsByClassName('govuk-heading-s');
+    expect(passcodeText[0].innerHTML).contains('Enter your 6-digit passcode', 'Could not find the enter the passcode header');
+  });
+
+  it('should display how many attempts the user has left', () => {
+    const attemptText = htmlRes.getElementsByClassName('govuk-body');
+    expect(attemptText[0].innerHTML).contains('You have 3 attempts', 'Could not find the attempts text');
+  });
+
+  it('should display a text input where the user can enter a 6 digit passcode', () => {
+    const input = htmlRes.getElementById('otp-code');
+    expect(input).exist;
+  });
+
+  it('should display the continue button', () => {
+    const continueButton = htmlRes.getElementsByClassName(buttonClass);
+    expect(continueButton[0].innerHTML).contains('Continue', 'Could not find continue button');
+  });
+
+  it('should display the reset passcode button', () => {
+    const resetPasscodeButton = htmlRes.getElementsByClassName(buttonClass);
+    expect(resetPasscodeButton[1].innerHTML).contains('Resend passcode', 'Could not find Resend passcode button');
+  });
+});

--- a/src/test/unit/views/subscription-management.test.ts
+++ b/src/test/unit/views/subscription-management.test.ts
@@ -1,0 +1,21 @@
+import {expect} from 'chai';
+import request from 'supertest';
+
+import {app} from '../../../main/app';
+
+const PAGE_URL = '/subscription-management';
+
+let htmlRes: Document;
+
+describe('Subscription Management Page', () => {
+  beforeAll(async () => {
+    await request(app).get(PAGE_URL).then(res => {
+      htmlRes = new DOMParser().parseFromString(res.text, 'text/html');
+    });
+  });
+
+  it('should display header', () => {
+    const header = htmlRes.getElementsByClassName('govuk-heading-l');
+    expect(header[0].innerHTML).contains('Subscription Management', 'Could not find correct value in header');
+  });
+});


### PR DESCRIPTION
### JIRA link ###

https://tools.hmcts.net/jira/browse/PUB-693

### Change description ###

This adds the login page using OTP codes.

This just covers the successful path. I have created a dummy subscription management for now, to show the navigation if successful. 

The page for this can be access directly at /otp-login

<img width="1006" alt="Screenshot 2021-09-06 at 09 10 03" src="https://user-images.githubusercontent.com/87066931/132183093-f6759032-3379-49fd-b2d1-881cd3d92b6c.png">

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
