### PR TITLE
PUB-693 - Removed javascript validation from field

### DIFF
--- a/src/main/controllers/OtpLoginController.ts
+++ b/src/main/controllers/OtpLoginController.ts
@@ -6,7 +6,7 @@ export default class OtpLoginController {
   }
 
   public post(req: Request, res: Response): void {
-    if (req.body['otp-code'] && req.body['otp-code'].length === 6 && req.body['otp-code'].match(/^[0-9]+$/)) {
+    if (req.body['otp-code'] && req.body['otp-code'].length === 6 && req.body['otp-code'].match(/^\d+$/)) {
       res.redirect('subscription-management');
     } else {
       res.redirect('otp-login');

--- a/src/main/controllers/OtpLoginController.ts
+++ b/src/main/controllers/OtpLoginController.ts
@@ -6,7 +6,7 @@ export default class OtpLoginController {
   }
 
   public post(req: Request, res: Response): void {
-    if (req.body['otp-code'] && req.body['otp-code'].length === 6) {
+    if (req.body['otp-code'] && req.body['otp-code'].length === 6 && req.body['otp-code'].match(/^[0-9]+$/)) {
       res.redirect('subscription-management');
     } else {
       res.redirect('otp-login');

--- a/src/main/views/otp-login.njk
+++ b/src/main/views/otp-login.njk
@@ -14,13 +14,8 @@
       govuk-input--width-10
       govuk-!-margin-right-2" id="otp-code" name="otp-code"
              inputmode="numeric"
-             type="number"
              pattern='[0-9]*'
-             aria-labelledby="input-label"
-             oninput="
-             if (this.value.length > 6) {
-              this.value = this.value.slice(0,6);
-             }">
+             aria-labelledby="input-label">
 
       <span class="govuk-body">You have 3 attempts</span>
     </div>

--- a/src/main/views/otp-login.njk
+++ b/src/main/views/otp-login.njk
@@ -15,7 +15,8 @@
       govuk-!-margin-right-2" id="otp-code" name="otp-code"
              inputmode="numeric"
              pattern='[0-9]*'
-             aria-labelledby="input-label">
+             aria-labelledby="input-label"
+             autocomplete="off">
 
       <span class="govuk-body">You have 3 attempts</span>
     </div>

--- a/src/test/unit/controllers/OtpLoginController.test.ts
+++ b/src/test/unit/controllers/OtpLoginController.test.ts
@@ -50,6 +50,21 @@ describe('Otp Login Controller', () => {
     responseMock.verify();
   });
 
+  it('should render same page if otp code is not digits', () => {
+    const otpLoginController = new OtpLoginController();
+
+    const response = { redirect: function() {return '';}} as unknown as Response;
+    const request = { body: { 'otp-login': 'abcdef'}} as unknown as Request;
+
+    const responseMock = sinon.mock(response);
+
+    responseMock.expects('redirect').once().withArgs('otp-login');
+
+    otpLoginController.post(request, response);
+
+    responseMock.verify();
+  });
+
   it('should render same page if no otp code is entered', () => {
     const otpLoginController = new OtpLoginController();
 


### PR DESCRIPTION
### JIRA link ###

https://tools.hmcts.net/jira/browse/PUB-693

### Change description ###

Removed the 6 digit limit and character validation from the input box in the frontend to follow govuk guidelines.

This is now handled in the backend. Right now if the user enters a code != 6 digits, or not numbers then it will not go to the subscription management page. The validation errors for this will be added in https://tools.hmcts.net/jira/browse/PUB-661

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
