### PR TITLE
Updated sonar project name to be more specific

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,4 +1,4 @@
-sonar.projectName=Publishing-information-project :: PI
+sonar.projectName=PIP-Frontend
 sonar.projectKey=Publishing-information-project-PI
 sonar.language=typescript
 sonar.sources=src/main


### PR DESCRIPTION
Updated "sonar.projectName=Publishing-information-project :: PI" to "sonar.projectName=PIP-Frontend" to be more specific and more easily found in Sonarcloud