### PR TITLE
PUB-732 - Subscription Add page

### DIFF
--- a/src/main/controllers/SubscriptionAddController.ts
+++ b/src/main/controllers/SubscriptionAddController.ts
@@ -23,7 +23,7 @@ export default class SubscriptionAddController {
         res.redirect('/');
         break;
       default:
-        res.redirect('subscription-add');
+        res.render('subscription-add', {selectionError: 'true'});
     }
   }
 }

--- a/src/main/controllers/SubscriptionAddController.ts
+++ b/src/main/controllers/SubscriptionAddController.ts
@@ -1,0 +1,29 @@
+import { Request, Response } from 'express';
+
+export default class SubscriptionAddController {
+  public get(req: Request, res: Response): void {
+    res.render('subscription-add');
+  }
+
+  public post(req: Request, res: Response): void {
+    switch(req.body['subscription-choice']) {
+      case 'case-reference': {
+        res.redirect('/');
+        break;
+      }
+      case 'urn': {
+        res.redirect('/');
+        break;
+      }
+      case 'name': {
+        res.redirect('/');
+        break;
+      }
+      case 'court-or-tribunal':
+        res.redirect('/');
+        break;
+      default:
+        res.redirect('subscription-add');
+    }
+  }
+}

--- a/src/main/routes/routes.ts
+++ b/src/main/routes/routes.ts
@@ -39,6 +39,8 @@ export default function(app: Application): void {
   app.post('/search-option', app.locals.container.cradle.searchOptionController.post);
   app.post('/search', app.locals.container.cradle.searchController.post);
 
+  app.get('/subscription-add', app.locals.container.cradle.subscriptionAddController.get);
+  app.post('/subscription-add', app.locals.container.cradle.subscriptionAddController.post);
   app.get('/subscription-management', app.locals.container.cradle.subscriptionManagementController.get);
 
   app.get('/view-option', app.locals.container.cradle.viewOptionController.get);

--- a/src/main/views/subscription-add.njk
+++ b/src/main/views/subscription-add.njk
@@ -1,6 +1,8 @@
 {% from "./macros/common-components.njk" import goBack, submitButton %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
 {% extends "template.njk" %}
 {% block pageTitle %}
@@ -18,44 +20,75 @@
 {% endblock %}
 
 {% block content %}
-  <form method="post">
-    {{ govukRadios({
-      idPrefix: "subscription-choice",
-      name: "subscription-choice",
-      fieldset: {
-        legend: {
-          text: 'How do you want to add a subscription?',
-          isPageHeading: true,
-          classes: "govuk-fieldset__legend--l"
-        }
-      },
-      items: [
+  {% if selectionError %}
+    {{ govukErrorSummary({
+      titleText: "There is a problem",
+      errorList: [
         {
-          value: "case-reference",
-          text: "By case reference number"
-        },
-        {
-          value: "urn",
-          text: "By unique reference number"
-        },
-        {
-          value: "name",
-          text: "By case name"
-        },
-        {
-          value: "court-or-tribunal",
-          text: "By court or tribunal"
+          text: "Please tell us how you would like to add a subscription",
+          href: "#subscription-choice"
         }
       ]
     }) }}
+  {% endif %}
+  <form method="post">
+    <div class="govuk-form-group">
+      <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+          <h1 class="govuk-fieldset__heading">
+            How do you want to add a subscription?
+          </h1>
+        </legend>
+
+        {{ govukInsetText({
+          text: "This service displays information about published lists only. Searches can only be performed against information contained
+          within published lists.",
+          classes: "govuk-!-margin-bottom-8"
+        }) }}
+        {% if selectionError %}
+          <span id="subscription-choice-error" class="govuk-error-message">
+            <span class="govuk-visually-hidden">Error:</span> Please tell us how you would like to add a subscription
+          </span>
+        {% endif %}
+        <div id= "subscription-choice" class="govuk-radios
+                                              govuk-!-margin-bottom-4
+                                              {% if selectionError %}govuk-form-group--error {% endif %}">
+          <div class="govuk-radios__item">
+            <input class="govuk-radios__input" id="subscription-choice-1" name="subscription-choice" type="radio" value="case-reference">
+            <label class="govuk-label govuk-radios__label" for="subscription-choice-1">
+              By case reference number
+            </label>
+          </div>
+          <div class="govuk-radios__item">
+            <input class="govuk-radios__input" id="subscription-choice-2" name="subscription-choice" type="radio" value="urn">
+            <label class="govuk-label govuk-radios__label" for="subscription-choice-2">
+              By unique reference number
+            </label>
+          </div>
+          <div class="govuk-radios__item">
+            <input class="govuk-radios__input" id="subscription-choice-3" name="subscription-choice" type="radio" value="name">
+            <label class="govuk-label govuk-radios__label" for="subscription-choice-3">
+              By case name
+            </label>
+          </div>
+          <div class="govuk-radios__item">
+            <input class="govuk-radios__input" id="subscription-choice-4" name="subscription-choice" type="radio" value="court-or-tribunal">
+            <label class="govuk-label govuk-radios__label" for="subscription-choice-4">
+              By court or tribunal
+            </label>
+          </div>
+        </div>
+
+      </fieldset>
+    </div>
     {{ submitButton() }}
   </form>
   <hr class="govuk-section-break--visible govuk-!-margin-top-7" />
   <div class="govuk-!-margin-bottom-2">
-    <a href="/search-option" class="govuk-link govuk-!-font-weight-bold">Manage your subscriptions</a>
+    <a href="/subscription-management" class="govuk-link govuk-!-font-weight-bold">Manage your subscriptions</a>
   </div>
   <div class="govuk-!-margin-bottom-9">
-    <a href="/subscription-add" class="govuk-link govuk-!-font-weight-bold">Find a court or tribunal list</a>
+    <a href="/search-option" class="govuk-link govuk-!-font-weight-bold">Find a court or tribunal list</a>
   </div>
 
 {% endblock %}

--- a/src/main/views/subscription-add.njk
+++ b/src/main/views/subscription-add.njk
@@ -1,0 +1,61 @@
+{% from "./macros/common-components.njk" import goBack, submitButton %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+
+{% extends "template.njk" %}
+{% block pageTitle %}
+  {{ "Add a subscription" | safe }}
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: text,
+    href: '#',
+    attributes: {
+      onClick: "history.back();"
+    }
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <form method="post">
+    {{ govukRadios({
+      idPrefix: "subscription-choice",
+      name: "subscription-choice",
+      fieldset: {
+        legend: {
+          text: 'How do you want to add a subscription?',
+          isPageHeading: true,
+          classes: "govuk-fieldset__legend--l"
+        }
+      },
+      items: [
+        {
+          value: "case-reference",
+          text: "By case reference number"
+        },
+        {
+          value: "urn",
+          text: "By unique reference number"
+        },
+        {
+          value: "name",
+          text: "By case name"
+        },
+        {
+          value: "court-or-tribunal",
+          text: "By court or tribunal"
+        }
+      ]
+    }) }}
+    {{ submitButton() }}
+  </form>
+  <hr class="govuk-section-break--visible govuk-!-margin-top-7" />
+  <div class="govuk-!-margin-bottom-2">
+    <a href="/search-option" class="govuk-link govuk-!-font-weight-bold">Manage your subscriptions</a>
+  </div>
+  <div class="govuk-!-margin-bottom-9">
+    <a href="/subscription-add" class="govuk-link govuk-!-font-weight-bold">Find a court or tribunal list</a>
+  </div>
+
+{% endblock %}

--- a/src/test/e2e/Helpers/Selectors.ts
+++ b/src/test/e2e/Helpers/Selectors.ts
@@ -38,4 +38,7 @@ module.exports = {
   ViewSearchRadioButton: '#view-choice',
   LiveHearingsRadioButton: '#view-choice-2',
 
+  //SubscriptionAdd selectors
+  SubscriptionAddTitle: 'h1.govuk-fieldset__heading',
+
 };

--- a/src/test/e2e/PageObjects/SubscriptionAdd.page.ts
+++ b/src/test/e2e/PageObjects/SubscriptionAdd.page.ts
@@ -1,0 +1,16 @@
+const helpers = require('../Helpers/Selectors');
+
+export class SubscriptionAddPage {
+
+  open(path): Promise<string> {
+    return browser.url(path);
+  }
+
+  async getPageTitle(): Promise<string> {
+    $(helpers.SubscriptionAddTitle).catch(() => {
+      console.log(`${helpers.SubscriptionAddTitle} not found`);
+    });
+
+    return $(helpers.SubscriptionAddTitle).getText();
+  }
+}

--- a/src/test/e2e/tests/specs.test.ts
+++ b/src/test/e2e/tests/specs.test.ts
@@ -8,9 +8,11 @@ import { OtpLoginPage } from '../pageobjects/OtpLogin.page';
 import { SubscriptionManagementPage } from '../pageobjects/SubscriptionManagement.page';
 import { ViewOptionPage } from '../PageObjects/ViewOption.page';
 import { LiveCaseCourtSearchControllerPage } from '../PageObjects/LiveCaseCourtSearchController.page';
+import { SubscriptionAddPage } from '../PageObjects/SubscriptionAdd.page';
 
 const homePage = new HomePage;
 const otpLoginPage = new OtpLoginPage();
+const subscriptionAddPage = new SubscriptionAddPage();
 let searchOptionsPage: SearchOptionsPage;
 let viewOptionPage: ViewOptionPage;
 let alphabeticalSearchPage: AlphabeticalSearchPage;
@@ -152,6 +154,14 @@ describe('Finding a court or tribunal listing', () => {
       subscriptionManagementPage = await otpLoginPage.clickContinue();
       expect(await subscriptionManagementPage.getPageTitle()).toEqual('Subscription Management');
     });
+  });
+
+  describe('Add a subscription path', () => {
+    it('should open the subscription add page', async () => {
+      await subscriptionAddPage.open('subscription-add');
+      expect(await subscriptionAddPage.getPageTitle()).toBe('How do you want to add a subscription?');
+    });
+
   });
 });
 

--- a/src/test/routes/subscription-add.test.ts
+++ b/src/test/routes/subscription-add.test.ts
@@ -58,8 +58,7 @@ describe('Subscription Add', () => {
         .post('/subscription-add')
         .send({'subscription-choice': ''})
         .expect((res) => {
-          expect(res.status).to.equal(302);
-          expect(res.header['location']).to.equal('subscription-add');
+          expect(res.status).to.equal(200);
         });
     });
   });

--- a/src/test/routes/subscription-add.test.ts
+++ b/src/test/routes/subscription-add.test.ts
@@ -1,0 +1,67 @@
+import { expect } from 'chai';
+import request from 'supertest';
+
+import { app } from '../../main/app';
+
+describe('Subscription Add', () => {
+  describe('on GET', () => {
+    test('should return subscription-add page', async () => {
+      await request(app)
+        .get('/subscription-add')
+        .expect((res) => expect(res.status).to.equal(200));
+    });
+  });
+
+  describe('on POST', () => {
+    test('should return home page when selection is case-reference', async () => {
+      await request(app)
+        .post('/subscription-add')
+        .send({'subscription-choice': 'case-reference'})
+        .expect((res) => {
+          expect(res.status).to.equal(302);
+          expect(res.header['location']).to.equal('/');
+        });
+    });
+
+    test('should return home page when selection is urn', async () => {
+      await request(app)
+        .post('/subscription-add')
+        .send({'subscription-choice': 'urn'})
+        .expect((res) => {
+          expect(res.status).to.equal(302);
+          expect(res.header['location']).to.equal('/');
+        });
+    });
+
+    test('should return home page when selection is name', async () => {
+      await request(app)
+        .post('/subscription-add')
+        .send({'subscription-choice': 'name'})
+        .expect((res) => {
+          expect(res.status).to.equal(302);
+          expect(res.header['location']).to.equal('/');
+        });
+    });
+
+    test('should return home page when selection is court-or-tribunal', async () => {
+      await request(app)
+        .post('/subscription-add')
+        .send({'subscription-choice': 'court-or-tribunal'})
+        .expect((res) => {
+          expect(res.status).to.equal(302);
+          expect(res.header['location']).to.equal('/');
+        });
+    });
+
+    test('should return subscription-add page when no selection is made', async () => {
+      await request(app)
+        .post('/subscription-add')
+        .send({'subscription-choice': ''})
+        .expect((res) => {
+          expect(res.status).to.equal(302);
+          expect(res.header['location']).to.equal('subscription-add');
+        });
+    });
+  });
+
+});

--- a/src/test/unit/controllers/SubscriptionAddController.test.ts
+++ b/src/test/unit/controllers/SubscriptionAddController.test.ts
@@ -82,12 +82,12 @@ describe('Subscription Add Controller', () => {
   it('should remain on page if no option is selected', () => {
     const subscriptionAddController = new SubscriptionAddController();
 
-    const response = { redirect: function() {return '';}} as unknown as Response;
+    const response = { render: function() {return '';}} as unknown as Response;
     const request = { body: { 'subscription-choice': ''}} as unknown as Request;
 
     const responseMock = sinon.mock(response);
 
-    responseMock.expects('redirect').once().withArgs('subscription-add');
+    responseMock.expects('render').once().withArgs('subscription-add', {selectionError: 'true'});
 
     subscriptionAddController.post(request, response);
 

--- a/src/test/unit/controllers/SubscriptionAddController.test.ts
+++ b/src/test/unit/controllers/SubscriptionAddController.test.ts
@@ -1,0 +1,97 @@
+import sinon from 'sinon';
+import { Request, Response } from 'express';
+import SubscriptionAddController from '../../../main/controllers/SubscriptionAddController';
+
+describe('Subscription Add Controller', () => {
+  it('should render the subscription add page', () => {
+    const subscriptionAddController = new SubscriptionAddController();
+
+    const response = { render: function() {return '';}} as unknown as Response;
+    const request = {} as unknown as Request;
+
+    const responseMock = sinon.mock(response);
+
+    responseMock.expects('render').once().withArgs('subscription-add');
+
+    subscriptionAddController.get(request, response);
+
+    responseMock.verify();
+  });
+
+  it('should render home page if choice is \'case-reference\'', () => {
+    const subscriptionAddController = new SubscriptionAddController();
+
+    const response = { redirect: function() {return '';}} as unknown as Response;
+    const request = { body: { 'subscription-choice': 'case-reference'}} as unknown as Request;
+
+    const responseMock = sinon.mock(response);
+
+    responseMock.expects('redirect').once().withArgs('/');
+
+    subscriptionAddController.post(request, response);
+
+    responseMock.verify();
+  });
+
+  it('should render home page if choice is \'urn\'', () => {
+    const subscriptionAddController = new SubscriptionAddController();
+
+    const response = { redirect: function() {return '';}} as unknown as Response;
+    const request = { body: { 'subscription-choice': 'urn'}} as unknown as Request;
+
+    const responseMock = sinon.mock(response);
+
+    responseMock.expects('redirect').once().withArgs('/');
+
+    subscriptionAddController.post(request, response);
+
+    responseMock.verify();
+  });
+
+
+  it('should render home page if choice is \'name\'', () => {
+    const subscriptionAddController = new SubscriptionAddController();
+
+    const response = { redirect: function() {return '';}} as unknown as Response;
+    const request = { body: { 'subscription-choice': 'name'}} as unknown as Request;
+
+    const responseMock = sinon.mock(response);
+
+    responseMock.expects('redirect').once().withArgs('/');
+
+    subscriptionAddController.post(request, response);
+
+    responseMock.verify();
+  });
+
+  it('should render home page if choice is \'court-or-tribunal\'', () => {
+    const subscriptionAddController = new SubscriptionAddController();
+
+    const response = { redirect: function() {return '';}} as unknown as Response;
+    const request = { body: { 'subscription-choice': 'court-or-tribunal'}} as unknown as Request;
+
+    const responseMock = sinon.mock(response);
+
+    responseMock.expects('redirect').once().withArgs('/');
+
+    subscriptionAddController.post(request, response);
+
+    responseMock.verify();
+  });
+
+  it('should remain on page if no option is selected', () => {
+    const subscriptionAddController = new SubscriptionAddController();
+
+    const response = { redirect: function() {return '';}} as unknown as Response;
+    const request = { body: { 'subscription-choice': ''}} as unknown as Request;
+
+    const responseMock = sinon.mock(response);
+
+    responseMock.expects('redirect').once().withArgs('subscription-add');
+
+    subscriptionAddController.post(request, response);
+
+    responseMock.verify();
+  });
+
+});

--- a/src/test/unit/views/subscription-add.test.ts
+++ b/src/test/unit/views/subscription-add.test.ts
@@ -5,8 +5,11 @@ import { app } from '../../../main/app';
 
 const PAGE_URL = '/subscription-add';
 const backButtonClass = 'govuk-back-link';
+const errorSummaryClass = 'govuk-error-summary';
+const errorMessageId = 'subscription-choice-error';
 const headingClass = 'govuk-fieldset__heading';
 const buttonClass = 'govuk-button';
+const subscriptionChoiceId = 'subscription-choice';
 const radioClass = 'govuk-radios__item';
 const linkClass = 'govuk-link';
 
@@ -20,7 +23,7 @@ const expectedLink1 = 'Manage your subscriptions';
 const expectedLink2 = 'Find a court or tribunal list';
 
 let htmlRes: Document;
-describe('Subscription add Page', () => {
+describe('Subscription add Page initial load', () => {
   beforeAll(async () => {
     await request(app).get(PAGE_URL).then(res => {
       htmlRes = new DOMParser().parseFromString(res.text, 'text/html');
@@ -33,9 +36,24 @@ describe('Subscription add Page', () => {
     expect(backLink[0].getAttribute('href')).equal('#', 'Back value does not contain correct link');
   });
 
+  it('should not display the error summary on loading', () => {
+    const errorSummary = htmlRes.getElementsByClassName(errorSummaryClass);
+    expect(errorSummary.length).equals(0, 'Error summary is incorrectly displayed');
+  });
+
   it('should display header',  () => {
     const header = htmlRes.getElementsByClassName(headingClass);
     expect(header[0].innerHTML).contains(expectedHeader, 'Could not find the header');
+  });
+
+  it('should not display the error message on loading', () => {
+    const errorMessage = htmlRes.getElementById(errorMessageId);
+    expect(errorMessage).not.exist;
+  });
+
+  it('should not display the radio error highlighting on load', () => {
+    const subscriptionChoice = htmlRes.getElementById(subscriptionChoiceId);
+    expect(subscriptionChoice.getAttribute('class')).not.contains('govuk-form-group--error');
   });
 
   it('should display continue button',  () => {
@@ -71,13 +89,38 @@ describe('Subscription add Page', () => {
   it('should display manage your subscriptions link',  () => {
     const links = htmlRes.getElementsByClassName(linkClass);
     expect(links[0].innerHTML).contains(expectedLink1, 'Could not find the link with text ' + expectedLink1);
-    expect(links[0].getAttribute('href')).equal('/search-option', 'Link value is not correct');
+    expect(links[0].getAttribute('href')).equal('/subscription-management', 'Link value is not correct');
   });
 
   it('should display find a court or tribunal list link',  () => {
     const links = htmlRes.getElementsByClassName(linkClass);
     expect(links[1].innerHTML).contains(expectedLink2, 'Could not find the link with text ' + expectedLink2);
-    expect(links[1].getAttribute('href')).equal('/subscription-add', 'Link value is not correct');
+    expect(links[1].getAttribute('href')).equal('/search-option', 'Link value is not correct');
+  });
+
+});
+
+describe('Subscription add page no selection entered', () => {
+  beforeAll(async () => {
+    await request(app).post(PAGE_URL).send({selectionError: true}).then(res => {
+      htmlRes = new DOMParser().parseFromString(res.text, 'text/html');
+    });
+
+    it('should display the error summary when no selection is entered', () => {
+      const errorSummary = htmlRes.getElementsByClassName(errorSummaryClass);
+      expect(errorSummary[0].innerHTML).contains(0, 'Please tell us how you would like to add a subscription');
+    });
+
+    it('should not display the error message when no selection is entered', () => {
+      const errorMessage = htmlRes.getElementById(errorMessageId);
+      expect(errorMessage.innerHTML).contains('Please tell us how you would like to add a subscription');
+    });
+
+    it('should not display the radio error highlighting when no selection is entered', () => {
+      const subscriptionChoice = htmlRes.getElementById(subscriptionChoiceId);
+      expect(subscriptionChoice.getAttribute('class')).contains('govuk-form-group--error');
+    });
+
   });
 
 });

--- a/src/test/unit/views/subscription-add.test.ts
+++ b/src/test/unit/views/subscription-add.test.ts
@@ -1,0 +1,83 @@
+import { expect } from 'chai';
+import request from 'supertest';
+
+import { app } from '../../../main/app';
+
+const PAGE_URL = '/subscription-add';
+const backButtonClass = 'govuk-back-link';
+const headingClass = 'govuk-fieldset__heading';
+const buttonClass = 'govuk-button';
+const radioClass = 'govuk-radios__item';
+const linkClass = 'govuk-link';
+
+const expectedHeader = 'How do you want to add a subscription?';
+const expectedButtonText = 'Continue';
+const expectedRadioLabel1 = 'By case reference number';
+const expectedRadioLabel2 = 'By unique reference number';
+const expectedRadioLabel3 = 'By case name';
+const expectedRadioLabel4 = 'By court or tribunal';
+const expectedLink1 = 'Manage your subscriptions';
+const expectedLink2 = 'Find a court or tribunal list';
+
+let htmlRes: Document;
+describe('Subscription add Page', () => {
+  beforeAll(async () => {
+    await request(app).get(PAGE_URL).then(res => {
+      htmlRes = new DOMParser().parseFromString(res.text, 'text/html');
+    });
+  });
+
+  it('should display a back button with the correct value', () => {
+    const backLink = htmlRes.getElementsByClassName(backButtonClass);
+    expect(backLink[0].innerHTML).contains('Back', 'Back button does not contain correct text');
+    expect(backLink[0].getAttribute('href')).equal('#', 'Back value does not contain correct link');
+  });
+
+  it('should display header',  () => {
+    const header = htmlRes.getElementsByClassName(headingClass);
+    expect(header[0].innerHTML).contains(expectedHeader, 'Could not find the header');
+  });
+
+  it('should display continue button',  () => {
+    const buttons = htmlRes.getElementsByClassName(buttonClass);
+    expect(buttons[0].innerHTML).contains(expectedButtonText, 'Could not find button');
+  });
+
+  it('should display 4 radio buttons', () => {
+    const radioButtons = htmlRes.getElementsByClassName(radioClass);
+    expect(radioButtons.length).equal(4, '4 radio buttons not found');
+  });
+
+  it('should display first radio button content',  () => {
+    const radioButtons = htmlRes.getElementsByClassName(radioClass);
+    expect(radioButtons[0].innerHTML).contains(expectedRadioLabel1, 'Could not find the radio button with label ' + expectedRadioLabel1);
+  });
+
+  it('should display second radio button content',  () => {
+    const radioButtons = htmlRes.getElementsByClassName(radioClass);
+    expect(radioButtons[1].innerHTML).contains(expectedRadioLabel2, 'Could not find the radio button with label ' + expectedRadioLabel2);
+  });
+
+  it('should display third radio button content',  () => {
+    const radioButtons = htmlRes.getElementsByClassName(radioClass);
+    expect(radioButtons[2].innerHTML).contains(expectedRadioLabel3, 'Could not find the radio button with label ' + expectedRadioLabel2);
+  });
+
+  it('should display fourth radio button content',  () => {
+    const radioButtons = htmlRes.getElementsByClassName(radioClass);
+    expect(radioButtons[3].innerHTML).contains(expectedRadioLabel4, 'Could not find the radio button with label ' + expectedRadioLabel2);
+  });
+
+  it('should display manage your subscriptions link',  () => {
+    const links = htmlRes.getElementsByClassName(linkClass);
+    expect(links[0].innerHTML).contains(expectedLink1, 'Could not find the link with text ' + expectedLink1);
+    expect(links[0].getAttribute('href')).equal('/search-option', 'Link value is not correct');
+  });
+
+  it('should display find a court or tribunal list link',  () => {
+    const links = htmlRes.getElementsByClassName(linkClass);
+    expect(links[1].innerHTML).contains(expectedLink2, 'Could not find the link with text ' + expectedLink2);
+    expect(links[1].getAttribute('href')).equal('/subscription-add', 'Link value is not correct');
+  });
+
+});


### PR DESCRIPTION
### JIRA link ###

https://tools.hmcts.net/jira/browse/PUB-732

### Change description ###

This PR adds the selection for what type of subscription to add, alongside the error state if no radio button is selected.

Each selection currently navigates to the home page, and will be linked up once the other screens have been implemented.

This currently needs to be accessed directly at /subscription-add


<img width="1031" alt="Screenshot 2021-09-24 at 14 11 22" src="https://user-images.githubusercontent.com/87066931/134679876-23fdf996-aeab-4d81-82ba-1aa05ee13f6c.png">


<img width="995" alt="Screenshot 2021-09-24 at 14 11 31" src="https://user-images.githubusercontent.com/87066931/134679923-41f8f1af-f128-46bc-a31b-9d766cfdeba0.png">

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
