### PR TITLE
Content updates for UAT

### DIFF
--- a/src/main/resources/locales/en/alphabetical-search.json
+++ b/src/main/resources/locales/en/alphabetical-search.json
@@ -1,7 +1,7 @@
 {
   "title": "Court List",
   "backToTop": "Back to top",
-  "heading": "Find a court or tribunal listing",
+  "heading": "Find a court or tribunal",
   "tableHeader1": "Court or tribunal",
   "tableHeader2": "Number of hearings",
   "error": {

--- a/src/main/resources/locales/en/hearing-list.json
+++ b/src/main/resources/locales/en/hearing-list.json
@@ -6,9 +6,9 @@
   "tableHeader1": "Court Number",
   "tableHeader2": "Case name",
   "tableHeader3": "Case number",
-  "tableHeader4": "Judges",
-  "tableHeader5": "Time",
+  "tableHeader4": "Overseen by",
+  "tableHeader5": "Date/Time",
   "tableHeader6": "Hearing platform",
   "relatedContent": "Related Content",
-  "a1": "Find a court or tribunal list"
+  "a1": "See another court or tribunal"
 }

--- a/src/main/resources/locales/en/home.json
+++ b/src/main/resources/locales/en/home.json
@@ -1,9 +1,9 @@
 {
   "title": "Start Page",
-  "header": "Find a court or tribunal hearing list",
+  "header": "See publications and information from a court or tribunal",
   "p1": "You can use this service to find and view information on hearings in courts and tribunals in England and Wales, and some non-devolved tribunals in Scotland.",
-  "p2": "Find a court or tribunal hearing list allows you to view:",
-  "bullets1": ["court or tribunal hearing list", "live hearing updates - Crown Court only"],
+  "p2": "This service allows you to view:",
+  "bullets1": ["Information from a court or tribunal", "live hearing updates - Crown Court only", "SJP – Single Justice Procedures Cases"],
   "startButton": "Start now",
   "p3": "This service is also available in ",
   "language": "Welsh (Cymraeg)",

--- a/src/main/resources/locales/en/live-case-status.json
+++ b/src/main/resources/locales/en/live-case-status.json
@@ -1,11 +1,11 @@
 {
   "title": " Live Cases Updates",
-  "heading": "Live hearing updates - daily court list",
+  "heading": "Live hearing updates",
   "p1": "The status of each hearing will be updated as events happen live in court",
   "emptyText": "<p class=\"govuk-!-font-weight-bold govuk-!-margin-2\">- No Information To Display</p>",
   "tableHeader1": "Court number",
   "tableHeader2": "Case number",
   "tableHeader3": "Case name",
   "tableHeader4": "Status",
-  "a1": "Find a court or tribunal list"
+  "a1": "See another court or tribunal"
 }

--- a/src/main/resources/locales/en/single-justice-procedure-search.json
+++ b/src/main/resources/locales/en/single-justice-procedure-search.json
@@ -1,3 +1,3 @@
 {
-  "title": "Single Justice Procedure list"
+  "title": "Single Justice Procedure case"
 }

--- a/src/main/resources/locales/en/view-option.json
+++ b/src/main/resources/locales/en/view-option.json
@@ -1,7 +1,7 @@
 {
   "title": "View Option",
   "radioLegend": "What would you like to view?",
-  "radio1": "Court or Tribunal hearing Publications",
+  "radio1": "Court or Tribunal publications",
   "radio2": "Live hearing updates - Crown Court only",
-  "radio3": "Single Justice Procedure list"
+  "radio3": "Single Justice Procedure case"
 }

--- a/src/main/views/live-case-status.njk
+++ b/src/main/views/live-case-status.njk
@@ -14,7 +14,7 @@
 {% endblock %}
 
 {% block content %}
-    <h2 class="govuk-heading-l">Live hearing updates - daily court list</h2>
+    <h2 class="govuk-heading-l">Live hearing updates</h2>
     <h3 class="govuk-heading-m">{{ courtName }}</h3>
     <p class=" govuk-body-lead">{{ updateDateTime }}</p>
     <p class="govuk-body">The status of each hearing will be updated as events happen live in court</p>

--- a/src/main/views/search-option.njk
+++ b/src/main/views/search-option.njk
@@ -23,7 +23,7 @@
                 }
             },
             hint: {
-              text: "The name of the court or tribunal can be found on a letter, email or text from us"
+              text: "The name of the court or tribunal may be found on a letter, email or text from us"
             },
             items: [
                 {

--- a/src/test/e2e/tests/specs.test.ts
+++ b/src/test/e2e/tests/specs.test.ts
@@ -29,9 +29,9 @@ let caseNameSearchPage: CaseNameSearchPage;
 let caseNameSearchResultsPage: CaseNameSearchResultsPage;
 
 describe('Finding a court or tribunal listing', () => {
-  it('should open main page with "Find a court or tribunal listing title', async () => {
+  it('should open main page with "See publications and information from a court or tribunal title', async () => {
     await homePage.open('');
-    expect(await homePage.getPageTitle()).toEqual('Find a court or tribunal hearing list');
+    expect(await homePage.getPageTitle()).toEqual('See publications and information from a court or tribunal');
   });
 
   it('should click on the "Start now button and navigate to View Options page', async () => {
@@ -70,7 +70,7 @@ describe('Finding a court or tribunal listing', () => {
 
     it('selecting first result should take you to to the hearings list page', async () => {
       liveCaseStatusPage = await liveCaseCourtSearchControllerPage.selectFirstValidListResult();
-      expect(await liveCaseStatusPage.getPageTitle()).toEqual('Live hearing updates - daily court list');
+      expect(await liveCaseStatusPage.getPageTitle()).toEqual('Live hearing updates');
     });
 
     it(`should have '${validCourtName}' as a sub title`, async () => {
@@ -83,7 +83,7 @@ describe('Finding a court or tribunal listing', () => {
 
   });
 
-  describe('Following the \'Single Justice Procedure list\' option', () => {
+  describe('Following the \'Single Justice Procedure case\' option', () => {
     after(async () => {
       await homePage.open('');
       viewOptionPage = await homePage.clickStartNowButton();
@@ -94,10 +94,10 @@ describe('Finding a court or tribunal listing', () => {
       viewOptionPage = await homePage.clickStartNowButton();
     });
 
-    it('should select \'Single Justice Procedure list\' option and navigate to Single Justice Procedure list page', async () => {
+    it('should select \'Single Justice Procedure case\' option and navigate to Single Justice Procedure case page', async () => {
       await viewOptionPage.selectSingleJusticeProcedureRadio();
       singleJusticeProcedureSearchPage = await viewOptionPage.clickContinueSingleJusticeProcedure();
-      expect(await singleJusticeProcedureSearchPage.getPageTitle()).toEqual('Single Justice Procedure list');
+      expect(await singleJusticeProcedureSearchPage.getPageTitle()).toEqual('Single Justice Procedure case');
     });
 
   });

--- a/src/test/unit/views/alphabetical-search.test.ts
+++ b/src/test/unit/views/alphabetical-search.test.ts
@@ -35,7 +35,7 @@ describe('Alphabetical Search page', () => {
   it('should contain the find a court heading', () => {
     const pageHeading = htmlRes.getElementsByClassName('govuk-heading-l');
     expect(pageHeading[0].innerHTML)
-      .contains('Find a court or tribunal listing', 'Page heading does not exist');
+      .contains('Find a court or tribunal', 'Page heading does not exist');
   });
 
   it('should contain letters that navigate to other sections of the page', () => {

--- a/src/test/unit/views/hearing-list.test.ts
+++ b/src/test/unit/views/hearing-list.test.ts
@@ -45,7 +45,7 @@ describe('Hearing List page', () => {
     expect(columnHeadings[0].innerHTML).contains('Court Number', 'Could not find court number header');
     expect(columnHeadings[1].innerHTML).contains('Case name', 'Could not find case name header');
     expect(columnHeadings[2].innerHTML).contains('Case number', 'Could not find court number header');
-    expect(columnHeadings[3].innerHTML).contains('Judges', 'Could not find judges header');
+    expect(columnHeadings[3].innerHTML).contains('Overseen by', 'Could not find judges header');
     expect(columnHeadings[4].innerHTML).contains('Time', 'Could not find time header');
     expect(columnHeadings[5].innerHTML).contains('Hearing platform', 'Could not find hearing platform header');
   });
@@ -76,7 +76,7 @@ describe('Hearing List page', () => {
   it('should display the link', () => {
     const link = htmlRes.getElementsByClassName('govuk-link');
 
-    expect(link.item(0).innerHTML).contains('Find a court or tribunal list', 'Link text is not present');
+    expect(link.item(0).innerHTML).contains('See another court or tribunal', 'Link text is not present');
     expect(link.item(0).getAttribute('href')).equal('/search-option', 'Link value is not correct');
   });
 

--- a/src/test/unit/views/home.test.ts
+++ b/src/test/unit/views/home.test.ts
@@ -6,7 +6,7 @@ const PAGE_URL = '/';
 const headingClass = 'govuk-heading-xl';
 const navigationClass = 'govuk-header__navigation-item';
 const startButtonClass = 'govuk-button govuk-button--start';
-const expectedHeader = 'Find a court or tribunal hearing list';
+const expectedHeader = 'See publications and information from a court or tribunal';
 
 let htmlRes: Document;
 describe('Home page', () => {

--- a/src/test/unit/views/live-case-status.test.ts
+++ b/src/test/unit/views/live-case-status.test.ts
@@ -7,7 +7,7 @@ import path from 'path';
 import {LiveCaseRequests} from '../../../main/resources/requests/liveCaseRequests';
 
 const PAGE_URL = '/live-case-status?courtId=1';
-const expectedHeader = 'Live hearing updates - daily court list';
+const expectedHeader = 'Live hearing updates';
 const expectedCourtName = 'Mutsu Court';
 let htmlRes: Document;
 
@@ -77,7 +77,7 @@ describe('Live Status page', () => {
   it('should display the link to go back to live case alphabet list', () => {
     const link = htmlRes.getElementsByClassName('govuk-link');
 
-    expect(link.item(3).innerHTML).contains('Find a court or tribunal list', 'Link text is not present');
+    expect(link.item(3).innerHTML).contains('See another court or tribunal', 'Link text is not present');
     expect(link.item(3).getAttribute('href')).equal('/live-case-alphabet-search', 'Link value is not correct');
   });
 });

--- a/src/test/unit/views/single-justice-procedure-search.test.ts
+++ b/src/test/unit/views/single-justice-procedure-search.test.ts
@@ -16,6 +16,6 @@ describe('Single Justice Procedure Search Page', () => {
 
   it('should display header', () => {
     const header = htmlRes.getElementsByClassName('govuk-heading-l');
-    expect(header[0].innerHTML).contains('Single Justice Procedure list', 'Could not find correct value in header');
+    expect(header[0].innerHTML).contains('Single Justice Procedure case', 'Could not find correct value in header');
   });
 });

--- a/src/test/unit/views/view-option.test.ts
+++ b/src/test/unit/views/view-option.test.ts
@@ -10,9 +10,9 @@ const radioClass = 'govuk-radios__item';
 
 const expectedHeader = 'What would you like to view?';
 const expectedButtonText = 'Continue';
-const expectedRadioLabel1 = 'Court or Tribunal hearing Publications';
+const expectedRadioLabel1 = 'Court or Tribunal publications';
 const expectedRadioLabel2 = 'Live hearing updates - Crown Court only';
-const expectedRadioLabel3 = 'Single Justice Procedure list';
+const expectedRadioLabel3 = 'Single Justice Procedure case';
 
 let htmlRes: Document;
 


### PR DESCRIPTION
Start page changes:
- Swap “Find a court or tribunal hearing list” to “See publications and information from a court or tribunal”
- Swap “Find a court or tribunal hearing list allows you to view:” to “This service allows you to view:”
- Swap “court or tribunal hearing list” to “Information from a court or tribunal”
- Add “SJP – Single Justice Procedures Cases” 

Landing page changes:
- Swap “Court or Tribunal hearing Publications” to “Court or Tribunal publications”
- Swap “Single Justice Procedure list” to “Single Justice Procedure case”
- Swap “The name of the court or tribunal can be found on a letter, email or text from us” to “The name of the court or tribunal may be found on a letter, email or text from us”

A-Z Screen changes:
- Swap “Find a court or tribunal listing” to “Find a court or tribunal” 

List screen changes:
- “Judge” to be replaced with “Overseen by”
- “Related Content Find a court or tribunal list” to be “Related Content See another court or tribunal”
- “Time” header to be updated to “Date/Time” 

LCSU screen changes:
- “Live hearing updates - daily court list” to be “Live hearing updates”
- Footer details “Find a court or tribunal list” to be “See another court or tribunal”