### PR TITLE
PUB-1182 - Split date inputs into own rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,13 @@ $ docker run -d -p 6379:6379 redis
 Run:
 
 ```bash
-$ yarn start  or  yarn start:dev
+$ yarn start 
+```
+
+or Run Dev mode:
+
+```bash
+$ yarn start:dev
 ```
 
 The applications's home page will be available at https://localhost:8080

--- a/src/main/resources/locales/en/manual-upload.json
+++ b/src/main/resources/locales/en/manual-upload.json
@@ -25,6 +25,8 @@
       {"text": "Bilingual English/Welsh", "value": "BI_LINGUAL"}
     ],
     "displayDateFrom": "Display file from",
-    "displayDateFromHint": "For example, 01 05 2022 to 19 05 2022"
+    "displayDateFromHint": "For example, 27 01 2022",
+    "displayDateTo": "Display file to",
+    "displayDateToHint": "For example, 18 02 2022"
   }
 }

--- a/src/main/views/manual-upload.njk
+++ b/src/main/views/manual-upload.njk
@@ -9,198 +9,208 @@
   {{ goBack() }}
 {% endblock %}
 {% block content %}
-  <h1 class="govuk-heading-xl">{{ title }}</h1>
-  <form method="post" enctype="multipart/form-data">
-    {% set fileErrorMessage = {text: errors.fileErrors} if errors.fileErrors else false %}
-    <div class="govuk-inset-text">
-      {{ govukFileUpload({
-        id: "manual-file-upload",
-        name: "manual-file-upload",
-        accept: ".json,.csv,.doc,.docx,.htm,.html",
-        label: {
-          text: fileUploadText
-        },
-        errorMessage: fileErrorMessage
-      }) }}
-    </div>
-
-    {% set courtFormGroupError = 'govuk-form-group--error' if errors.formErrors.courtError else 'govuk-form-group' %}
-    {% set inputError = 'govuk-input--error' if errors.formErrors.courtError else '' %}
-    <div id="form-wrapper" class="govuk-!-margin-bottom-9 ">
-      <div class="govuk-!-margin-bottom-3 govuk-!-width-one-third {{ courtFormGroupError }}">
-        <label id="search-input-title" class="govuk-label" for="search-input">
-         {{ form.court }}
-        </label>
-        {% if errors.formErrors.courtError %}
-          <span class="govuk-error-message">{{ errors.formErrors.courtError }}</span>
-        {% endif %}
-        <div class="{{ inputError }}" id="search-input-container"></div>
+  <div class="parent-box">
+    <h1 class="govuk-heading-xl">{{ title }}</h1>
+    <form method="post" enctype="multipart/form-data">
+      {% set fileErrorMessage = {text: errors.fileErrors} if errors.fileErrors else false %}
+      <div class="govuk-inset-text">
+        {{ govukFileUpload({
+          id: "manual-file-upload",
+          name: "manual-file-upload",
+          accept: ".json,.csv,.doc,.docx,.htm,.html",
+          label: {
+            text: fileUploadText
+          },
+          errorMessage: fileErrorMessage
+        }) }}
       </div>
 
-{#      To be included once additional list types become available, currently only LIST is available#}
-{#      <div class="govuk-form-group govuk-!-width-one-third" id="artefactType-question">#}
-{#        <label class="govuk-label" for="artefactType">#}
-{#          Document Type#}
-{#        </label>#}
-{#        <select class="govuk-select govuk-!-width-full" id="artefactType" name="artefactType">#}
-{#          <option value="LIST" selected>List</option>#}
-{#          <option value="JUDGEMENT_AND_OUTCOME">Judgement and Outcomes</option>#}
-{#        </select>#}
-{#      </div>#}
-
-      <div class="govuk-form-group govuk-inset-text govuk-!-padding-right-0">
-        <div id="list-question" class="govuk-!-margin-bottom-3 govuk-!-width-one-half">
-          {{ govukSelect({
-            classes: 'govuk-!-width-two-thirds',
-            id: "listType",
-            name: "listType",
-            label: {
-              text: form.listType
-            },
-            items: listItems.listSubtypes
-          }) }}
+      {% set courtFormGroupError = 'govuk-form-group--error' if errors.formErrors.courtError else 'govuk-form-group' %}
+      {% set inputError = 'govuk-input--error' if errors.formErrors.courtError else '' %}
+      <div id="form-wrapper" class="govuk-!-margin-bottom-9 ">
+        <div class="govuk-!-margin-bottom-3 govuk-!-width-one-third {{ courtFormGroupError }}">
+          <label id="search-input-title" class="govuk-label" for="search-input">
+           {{ form.court }}
+          </label>
+          {% if errors.formErrors.courtError %}
+            <span class="govuk-error-message">{{ errors.formErrors.courtError }}</span>
+          {% endif %}
+          <div class="{{ inputError }}" id="search-input-container"></div>
         </div>
 
-        <div id="judgement-question" class="admin-default-hide govuk-!-margin-bottom-3">
-          {{ govukSelect({
-            classes: 'govuk-!-width-two-thirds',
-            id: "judgementType",
-            name: "judgementType",
-            label: {
-              text: form.listType
-            },
-            items: listItems.judgementsOutcomesSubtypes
-          }) }}
+  {#      To be included once additional list types become available, currently only LIST is available#}
+  {#      <div class="govuk-form-group govuk-!-width-one-third" id="artefactType-question">#}
+  {#        <label class="govuk-label" for="artefactType">#}
+  {#          Document Type#}
+  {#        </label>#}
+  {#        <select class="govuk-select govuk-!-width-full" id="artefactType" name="artefactType">#}
+  {#          <option value="LIST" selected>List</option>#}
+  {#          <option value="JUDGEMENT_AND_OUTCOME">Judgement and Outcomes</option>#}
+  {#        </select>#}
+  {#      </div>#}
+
+        <div class="govuk-form-group govuk-inset-text govuk-!-padding-right-0">
+          <div id="list-question" class="govuk-!-margin-bottom-3 govuk-!-width-one-half">
+            {{ govukSelect({
+              classes: 'govuk-!-width-two-thirds',
+              id: "listType",
+              name: "listType",
+              label: {
+                text: form.listType
+              },
+              items: listItems.listSubtypes
+            }) }}
+          </div>
+
+          <div id="judgement-question" class="admin-default-hide govuk-!-margin-bottom-3">
+            {{ govukSelect({
+              classes: 'govuk-!-width-two-thirds',
+              id: "judgementType",
+              name: "judgementType",
+              label: {
+                text: form.listType
+              },
+              items: listItems.judgementsOutcomesSubtypes
+            }) }}
+          </div>
+
+          {% set cdFromError = 'govuk-input--error' if errors.formErrors.contentDateError else '' %}
+          {% set cdFormGroupError = 'govuk-form-group--error' if errors.formErrors.contentDateError else 'govuk-form-group' %}
+
+          <div class="{{ cdFormGroupError }} govuk-width-!-one-fourth">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="content-date">
+              <legend class="govuk-fieldset__legend">
+                {{ form.contentDate }}
+              </legend>
+              {% if errors.formErrors.contentDateError %}
+                <span class="govuk-error-message">{{ errors.formErrors.contentDateError }}</span>
+              {% endif %}
+              <div id="content-date-hint" class="govuk-hint">
+                {{ form.contentDateHint }}
+              </div>
+              <div class="govuk-date-input" id="content-date-from">
+                <div class="govuk-date-input__item">
+                  <div class="govuk-form-group">
+                    <label class="govuk-label govuk-date-input__label" for="content-date-from-day">
+                      {{ form.day }}
+                    </label>
+                    <input class="govuk-input govuk-date-input__input govuk-input--width-2 {{ cdFromError }}" id="content-date-from-day" name="content-date-from-day" type="text" pattern="[0-9]*" inputmode="numeric"></div>
+                </div>
+                <div class="govuk-date-input__item">
+                  <div class="govuk-form-group">
+                    <label class="govuk-label govuk-date-input__label" for="content-date-from-month">
+                      {{ form.month }}
+                    </label>
+                    <input class="govuk-input govuk-date-input__input govuk-input--width-2 {{ cdFromError }}" id="content-date-from-month" name="content-date-from-month" type="text" pattern="[0-9]*" inputmode="numeric"></div>
+                </div>
+                <div class="govuk-date-input__item">
+                  <div class="govuk-form-group">
+                    <label class="govuk-label govuk-date-input__label" for="content-date-from-year">
+                      {{ form.year }}
+                    </label>
+                    <input class="govuk-input govuk-date-input__input govuk-input--width-4 {{ cdFromError }}" id="content-date-from-year" name="content-date-from-year" type="text" pattern="[0-9]*" inputmode="numeric"></div>
+                </div>
+              </div>
+            </fieldset>
+          </div>
         </div>
+        {{ govukSelect({
+          classes: 'govuk-!-width-one-third',
+          id: "classification",
+          name: "classification",
+          label: {
+            text: form.classificationText
+          },
+          items: form.classification
+        }) }}
 
-        {% set cdFromError = 'govuk-input--error' if errors.formErrors.contentDateError else '' %}
-        {% set cdFormGroupError = 'govuk-form-group--error' if errors.formErrors.contentDateError else 'govuk-form-group' %}
+        {{ govukSelect({
+          classes: 'govuk-!-width-one-third',
+          id: "language",
+          name: "language",
+          label: {
+            text: form.languageText
+          },
+          items: form.language
+        }) }}
 
-        <div class="{{ cdFormGroupError }} govuk-width-!-one-fourth">
-          <fieldset class="govuk-fieldset" role="group" aria-describedby="content-date">
-            <legend class="govuk-fieldset__legend">
-              {{ form.contentDate }}
-            </legend>
-            {% if errors.formErrors.contentDateError %}
-              <span class="govuk-error-message">{{ errors.formErrors.contentDateError }}</span>
+        {% set displayFromError = 'govuk-input--error' if errors.formErrors.displayDateError.from else '' %}
+        {% set displayToError = 'govuk-input--error' if errors.formErrors.displayDateError.to else '' %}
+        {% set displayFormGroupError = 'govuk-form-group--error' if errors.formErrors.displayDateError else 'govuk-form-group' %}
+        {% set displayErrorMessage = errors.formErrors.displayDateError.from or errors.formErrors.displayDateError.to or errors.formErrors.displayDateError.range%}
+
+        <div class="{{ displayFormGroupError }}">
+          <fieldset class="govuk-fieldset" role="group" aria-describedby="display-date-from">
+            <legend class="govuk-fieldset__legend">{{ form.displayDateFrom }}</legend>
+            {% if errors.formErrors.displayDateError %}
+              <span class="govuk-error-message">{{ displayErrorMessage }}</span>
             {% endif %}
-            <div id="content-date-hint" class="govuk-hint">
-              {{ form.contentDateHint }}
+            <div id="display-date-hint" class="govuk-hint">
+              {{ form.displayDateFromHint }}
             </div>
-            <div class="govuk-date-input" id="content-date-from">
+            <div class="govuk-date-input" id="display-date-from">
               <div class="govuk-date-input__item">
                 <div class="govuk-form-group">
-                  <label class="govuk-label govuk-date-input__label" for="content-date-from-day">
+                  <label class="govuk-label govuk-date-input__label" for="display-date-from-day">
                     {{ form.day }}
                   </label>
-                  <input class="govuk-input govuk-date-input__input govuk-input--width-2 {{ cdFromError }}" id="content-date-from-day" name="content-date-from-day" type="text" pattern="[0-9]*" inputmode="numeric"></div>
+                  <input class="govuk-input govuk-date-input__input govuk-input--width-2 {{ displayFromError }}" id="display-date-from-day" name="display-date-from-day" type="text" pattern="[0-9]*" inputmode="numeric"></div>
               </div>
               <div class="govuk-date-input__item">
                 <div class="govuk-form-group">
-                  <label class="govuk-label govuk-date-input__label" for="content-date-from-month">
+                  <label class="govuk-label govuk-date-input__label" for="display-date-from-month">
                     {{ form.month }}
                   </label>
-                  <input class="govuk-input govuk-date-input__input govuk-input--width-2 {{ cdFromError }}" id="content-date-from-month" name="content-date-from-month" type="text" pattern="[0-9]*" inputmode="numeric"></div>
+                  <input class="govuk-input govuk-date-input__input govuk-input--width-2 {{ displayFromError }}" id="display-date-from-month" name="display-date-from-month" type="text" pattern="[0-9]*" inputmode="numeric"></div>
               </div>
               <div class="govuk-date-input__item">
                 <div class="govuk-form-group">
-                  <label class="govuk-label govuk-date-input__label" for="content-date-from-year">
+                  <label class="govuk-label govuk-date-input__label" for="display-date-from-year">
                     {{ form.year }}
                   </label>
-                  <input class="govuk-input govuk-date-input__input govuk-input--width-4 {{ cdFromError }}" id="content-date-from-year" name="content-date-from-year" type="text" pattern="[0-9]*" inputmode="numeric"></div>
+                  <input class="govuk-input govuk-date-input__input govuk-input--width-4 {{ displayFromError }}" id="display-date-from-year" name="display-date-from-year" type="text" pattern="[0-9]*" inputmode="numeric"></div>
               </div>
             </div>
           </fieldset>
+          <fieldset class="govuk-fieldset govuk-!-margin-top-6" role="group" aria-describedby="display-date-to">
+            <legend class="govuk-fieldset__legend">{{ form.displayDateTo }}</legend>
+            {% if errors.formErrors.displayDateError %}
+              <span class="govuk-error-message">{{ displayErrorMessage }}</span>
+            {% endif %}
+            <div id="display-date-hint" class="govuk-hint">
+              {{ form.displayDateToHint }}
+            </div>
+            <div class="govuk-date-input" id="display-date-to">
+              <div class="govuk-date-input__item">
+                <div class="govuk-form-group">
+                  <label class="govuk-label govuk-date-input__label" for="display-date-to-day">
+                    {{ form.day }}
+                  </label>
+                  <input class="govuk-input govuk-date-input__input govuk-input--width-2 {{ displayToError }}" id="display-date-to-day" name="display-date-to-day" type="text" pattern="[0-9]*" inputmode="numeric"></div>
+              </div>
+              <div class="govuk-date-input__item">
+                <div class="govuk-form-group">
+                  <label class="govuk-label govuk-date-input__label" for="display-date-to-month">
+                    {{ form.month }}
+                  </label>
+                  <input class="govuk-input govuk-date-input__input govuk-input--width-2 {{ displayToError }}" id="display-date-to-month" name="display-date-to-month" type="text" pattern="[0-9]*" inputmode="numeric"></div>
+              </div>
+              <div class="govuk-date-input__item">
+                <div class="govuk-form-group">
+                  <label class="govuk-label govuk-date-input__label" for="display-date-to-year">
+                    {{ form.year }}
+                  </label>
+                  <input class="govuk-input govuk-date-input__input govuk-input--width-4 {{ displayToError }}" id="display-date-to-year" name="display-date-to-year" type="text" pattern="[0-9]*" inputmode="numeric"></div>
+              </div>
+            </div>
+          </fieldset>
+
         </div>
       </div>
-      {{ govukSelect({
-        classes: 'govuk-!-width-one-third',
-        id: "classification",
-        name: "classification",
-        label: {
-          text: form.classificationText
-        },
-        items: form.classification
-      }) }}
-
-      {{ govukSelect({
-        classes: 'govuk-!-width-one-third',
-        id: "language",
-        name: "language",
-        label: {
-          text: form.languageText
-        },
-        items: form.language
-      }) }}
-
-      {% set displayFromError = 'govuk-input--error' if errors.formErrors.displayDateError.from else '' %}
-      {% set displayToError = 'govuk-input--error' if errors.formErrors.displayDateError.to else '' %}
-      {% set displayFormGroupError = 'govuk-form-group--error' if errors.formErrors.displayDateError else 'govuk-form-group' %}
-      {% set displayErrorMessage = errors.formErrors.displayDateError.from or errors.formErrors.displayDateError.to or errors.formErrors.displayDateError.range%}
-
-      <div class="{{ displayFormGroupError }}">
-        <fieldset class="govuk-fieldset" role="group" aria-describedby="display-date">
-          <legend class="govuk-fieldset__legend">{{ form.displayDateFrom }}</legend>
-          {% if errors.formErrors.displayDateError %}
-            <span class="govuk-error-message">{{ displayErrorMessage }}</span>
-          {% endif %}
-          <div id="display-date-hint" class="govuk-hint">
-            {{ form.displayDateFromHint }}
-          </div>
-          <div class="govuk-date-input" id="display-date-from">
-            <div class="govuk-date-input__item">
-              <div class="govuk-form-group">
-                <label class="govuk-label govuk-date-input__label" for="display-date-from-day">
-                  {{ form.day }}
-                </label>
-                <input class="govuk-input govuk-date-input__input govuk-input--width-2 {{ displayFromError }}" id="display-date-from-day" name="display-date-from-day" type="text" pattern="[0-9]*" inputmode="numeric"></div>
-            </div>
-            <div class="govuk-date-input__item">
-              <div class="govuk-form-group">
-                <label class="govuk-label govuk-date-input__label" for="display-date-from-month">
-                  {{ form.month }}
-                </label>
-                <input class="govuk-input govuk-date-input__input govuk-input--width-2 {{ displayFromError }}" id="display-date-from-month" name="display-date-from-month" type="text" pattern="[0-9]*" inputmode="numeric"></div>
-            </div>
-            <div class="govuk-date-input__item">
-              <div class="govuk-form-group">
-                <label class="govuk-label govuk-date-input__label" for="display-date-from-year">
-                  {{ form.year }}
-                </label>
-                <input class="govuk-input govuk-date-input__input govuk-input--width-4 {{ displayFromError }}" id="display-date-from-year" name="display-date-from-year" type="text" pattern="[0-9]*" inputmode="numeric"></div>
-            </div>
-          </div>
-          <div class="admin-form-offset govuk-body">to</div>
-          <div class="govuk-date-input" id="display-date-to">
-            <div class="govuk-date-input__item">
-              <div class="govuk-form-group">
-                <label class="govuk-label govuk-date-input__label" for="display-date-to-day">
-                  {{ form.day }}
-                </label>
-                <input class="govuk-input govuk-date-input__input govuk-input--width-2 {{ displayToError }}" id="display-date-to-day" name="display-date-to-day" type="text" pattern="[0-9]*" inputmode="numeric"></div>
-            </div>
-            <div class="govuk-date-input__item">
-              <div class="govuk-form-group">
-                <label class="govuk-label govuk-date-input__label" for="display-date-to-month">
-                  {{ form.month }}
-                </label>
-                <input class="govuk-input govuk-date-input__input govuk-input--width-2 {{ displayToError }}" id="display-date-to-month" name="display-date-to-month" type="text" pattern="[0-9]*" inputmode="numeric"></div>
-            </div>
-            <div class="govuk-date-input__item">
-              <div class="govuk-form-group">
-                <label class="govuk-label govuk-date-input__label" for="display-date-to-year">
-                  {{ form.year }}
-                </label>
-                <input class="govuk-input govuk-date-input__input govuk-input--width-4 {{ displayToError }}" id="display-date-to-year" name="display-date-to-year" type="text" pattern="[0-9]*" inputmode="numeric"></div>
-            </div>
-          </div>
-        </fieldset>
-      </div>
-    </div>
-
-    {{ submitButton() }}
-  </form>
-
+      {{ submitButton() }}
+    </form>
+    {{ super() }}
+  </div>
 {% endblock %}
 
 {% block bodyEnd %}
@@ -213,7 +223,7 @@
 
   <script src="/assets/js/accessible-autocomplete.min.js"></script>
   <script>
-    // removed whilst 1 list type is availble, kept in as request to be able to switch back when needed
+    // removed whilst 1 list type is available, kept in as request to be able to switch back when needed
     // const block = document.getElementById('artefactType');
     // const listQuestion = document.getElementById('list-question');
     // const judgementQuestion = document.getElementById('judgement-question');
@@ -250,7 +260,6 @@
     {% set populatedDisplayDateToDay = formData['display-date-to-day'] if formData['display-date-to-day'] else '' %}
     {% set populatedDisplayDateToMonth = formData['display-date-to-month'] if formData['display-date-to-month'] else '' %}
     {% set populatedDisplayDateToYear = formData['display-date-to-year'] if formData['display-date-to-year'] else '' %}
-
 
     document.getElementById('listType').value = {{ populatedListType | dump | safe }};
     document.getElementById('content-date-from-day').value = {{ populatedContentDateFromDay | dump | safe }};

--- a/src/main/views/manual-upload.njk
+++ b/src/main/views/manual-upload.njk
@@ -147,53 +147,51 @@
           <div id="display-date-hint" class="govuk-hint">
             {{ form.displayDateFromHint }}
           </div>
-          <div class="govuk-grid-row">
-            <div class="govuk-date-input" id="display-date-from">
-              <div class="govuk-date-input__item">
-                <div class="govuk-form-group">
-                  <label class="govuk-label govuk-date-input__label" for="display-date-from-day">
-                    {{ form.day }}
-                  </label>
-                  <input class="govuk-input govuk-date-input__input govuk-input--width-2 {{ displayFromError }}" id="display-date-from-day" name="display-date-from-day" type="text" pattern="[0-9]*" inputmode="numeric"></div>
-              </div>
-              <div class="govuk-date-input__item">
-                <div class="govuk-form-group">
-                  <label class="govuk-label govuk-date-input__label" for="display-date-from-month">
-                    {{ form.month }}
-                  </label>
-                  <input class="govuk-input govuk-date-input__input govuk-input--width-2 {{ displayFromError }}" id="display-date-from-month" name="display-date-from-month" type="text" pattern="[0-9]*" inputmode="numeric"></div>
-              </div>
-              <div class="govuk-date-input__item">
-                <div class="govuk-form-group">
-                  <label class="govuk-label govuk-date-input__label" for="display-date-from-year">
-                    {{ form.year }}
-                  </label>
-                  <input class="govuk-input govuk-date-input__input govuk-input--width-4 {{ displayFromError }}" id="display-date-from-year" name="display-date-from-year" type="text" pattern="[0-9]*" inputmode="numeric"></div>
-              </div>
+          <div class="govuk-date-input" id="display-date-from">
+            <div class="govuk-date-input__item">
+              <div class="govuk-form-group">
+                <label class="govuk-label govuk-date-input__label" for="display-date-from-day">
+                  {{ form.day }}
+                </label>
+                <input class="govuk-input govuk-date-input__input govuk-input--width-2 {{ displayFromError }}" id="display-date-from-day" name="display-date-from-day" type="text" pattern="[0-9]*" inputmode="numeric"></div>
             </div>
-            <div class="admin-form-offset govuk-body">to</div>
-            <div class="govuk-date-input" id="display-date-to">
-              <div class="govuk-date-input__item">
-                <div class="govuk-form-group">
-                  <label class="govuk-label govuk-date-input__label" for="display-date-to-day">
-                    {{ form.day }}
-                  </label>
-                  <input class="govuk-input govuk-date-input__input govuk-input--width-2 {{ displayToError }}" id="display-date-to-day" name="display-date-to-day" type="text" pattern="[0-9]*" inputmode="numeric"></div>
-              </div>
-              <div class="govuk-date-input__item">
-                <div class="govuk-form-group">
-                  <label class="govuk-label govuk-date-input__label" for="display-date-to-month">
-                    {{ form.month }}
-                  </label>
-                  <input class="govuk-input govuk-date-input__input govuk-input--width-2 {{ displayToError }}" id="display-date-to-month" name="display-date-to-month" type="text" pattern="[0-9]*" inputmode="numeric"></div>
-              </div>
-              <div class="govuk-date-input__item">
-                <div class="govuk-form-group">
-                  <label class="govuk-label govuk-date-input__label" for="display-date-to-year">
-                    {{ form.year }}
-                  </label>
-                  <input class="govuk-input govuk-date-input__input govuk-input--width-4 {{ displayToError }}" id="display-date-to-year" name="display-date-to-year" type="text" pattern="[0-9]*" inputmode="numeric"></div>
-              </div>
+            <div class="govuk-date-input__item">
+              <div class="govuk-form-group">
+                <label class="govuk-label govuk-date-input__label" for="display-date-from-month">
+                  {{ form.month }}
+                </label>
+                <input class="govuk-input govuk-date-input__input govuk-input--width-2 {{ displayFromError }}" id="display-date-from-month" name="display-date-from-month" type="text" pattern="[0-9]*" inputmode="numeric"></div>
+            </div>
+            <div class="govuk-date-input__item">
+              <div class="govuk-form-group">
+                <label class="govuk-label govuk-date-input__label" for="display-date-from-year">
+                  {{ form.year }}
+                </label>
+                <input class="govuk-input govuk-date-input__input govuk-input--width-4 {{ displayFromError }}" id="display-date-from-year" name="display-date-from-year" type="text" pattern="[0-9]*" inputmode="numeric"></div>
+            </div>
+          </div>
+          <div class="admin-form-offset govuk-body">to</div>
+          <div class="govuk-date-input" id="display-date-to">
+            <div class="govuk-date-input__item">
+              <div class="govuk-form-group">
+                <label class="govuk-label govuk-date-input__label" for="display-date-to-day">
+                  {{ form.day }}
+                </label>
+                <input class="govuk-input govuk-date-input__input govuk-input--width-2 {{ displayToError }}" id="display-date-to-day" name="display-date-to-day" type="text" pattern="[0-9]*" inputmode="numeric"></div>
+            </div>
+            <div class="govuk-date-input__item">
+              <div class="govuk-form-group">
+                <label class="govuk-label govuk-date-input__label" for="display-date-to-month">
+                  {{ form.month }}
+                </label>
+                <input class="govuk-input govuk-date-input__input govuk-input--width-2 {{ displayToError }}" id="display-date-to-month" name="display-date-to-month" type="text" pattern="[0-9]*" inputmode="numeric"></div>
+            </div>
+            <div class="govuk-date-input__item">
+              <div class="govuk-form-group">
+                <label class="govuk-label govuk-date-input__label" for="display-date-to-year">
+                  {{ form.year }}
+                </label>
+                <input class="govuk-input govuk-date-input__input govuk-input--width-4 {{ displayToError }}" id="display-date-to-year" name="display-date-to-year" type="text" pattern="[0-9]*" inputmode="numeric"></div>
             </div>
           </div>
         </fieldset>

--- a/src/main/views/manual-upload.njk
+++ b/src/main/views/manual-upload.njk
@@ -177,7 +177,7 @@
             {% if errors.formErrors.displayDateError %}
               <span class="govuk-error-message">{{ displayErrorMessage }}</span>
             {% endif %}
-            <div id="display-date-hint" class="govuk-hint">
+            <div id="display-date-to-hint" class="govuk-hint">
               {{ form.displayDateToHint }}
             </div>
             <div class="govuk-date-input" id="display-date-to">

--- a/src/test/unit/views/manual-upload.test.ts
+++ b/src/test/unit/views/manual-upload.test.ts
@@ -21,7 +21,8 @@ const expectedCourtNameQuestion = 'Court name';
 const expectedCourtNameContainer = 'search-input-container';
 const expectedListType = 'List type';
 const expectedHearingDates = 'Hearing start date';
-const expectedDisplayDates = 'Display file from';
+const expectedDisplayDateFrom = 'Display file from';
+const expectedDisplayDateTo = 'Display file to';
 const expectedClassification = 'Available to';
 const expectedLanguage = 'Language';
 const buttonText = 'Continue';
@@ -98,9 +99,10 @@ describe('Manual upload page', () => {
     });
 
     it('should display display date question', () => {
-      const displayDate = formElements.getElementsByClassName(fieldSetClass)[1];
-      expect(displayDate.innerHTML).contains(expectedDisplayDates, 'Could not find inset content date question');
-      expect(displayDate.getElementsByClassName(dateInputClass).length).equals(2, 'Could not find inset content date');
+      const displayDateFrom = formElements.getElementsByClassName(fieldSetClass)[1];
+      const displayDateTo = formElements.getElementsByClassName(fieldSetClass)[2];
+      expect(displayDateFrom.innerHTML).contains(expectedDisplayDateFrom, 'Could not find inset content date question');
+      expect(displayDateTo.innerHTML).contains(expectedDisplayDateTo, 'Could not find inset content date question');
     });
 
     it('should display continue button', () => {


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/PUB-1182


### Change description ###
Split display date files into own rows
Wrap page in parent box and include super call (futureproofing for Kurt's back to top implementation)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
![split](https://user-images.githubusercontent.com/25640912/158997088-2a3797ca-383a-4890-8b5c-207e5abbf2a1.PNG)
