### PR TITLE
PUB-1432 admin MFA loophole fix

### DIFF
--- a/.github/workflows/close-pr.yml
+++ b/.github/workflows/close-pr.yml
@@ -27,7 +27,8 @@ jobs:
         id: bootstrapKv
 
       - run: |
-          newUrl="https://pip-frontend-pr-${PR_NUMBER}.dev.platform.hmcts.net/login/return"
+          mediaSignInUrl="https://pip-frontend-pr-${PR_NUMBER}.dev.platform.hmcts.net/login/return"
+          adminSignInUrl="https://pip-frontend-pr-${PR_NUMBER}.dev.platform.hmcts.net/login/admin/return"
           targetAppName="pip-frontend-stg"
 
           azureClientId="${B2C_CLIENT_ID}"
@@ -45,17 +46,11 @@ jobs:
 
           echo "Found Reply URLs"
           echo $replyUrls
-
-          if [[ "${replyUrls}" =~ "${existingUrl}" ]]; then
-              echo "Reply URLs contains $existingUrl"
-              echo "Remove domain $existingUrl"
-
+          if [[ "${replyUrls}" =~ "${mediaSignInUrl}" || "${replyUrls}" =~ "${adminSignInUrl}" ]]; then
+              echo "Reply URLs contains $mediaSignInUrl or $adminSignInUrl"
               readarray -t my_array < <(echo "$replyUrls" | jq -c '.[]')
-
-              # iterate through the Bash array
               for item in "${my_array[@]}"; do
-                  if [[ $item != "\"$existingUrl\"" ]]; then
-                      echo "Url: $item"
+                  if [[ $item != "\"$mediaSignInUrl\"" && $item != "\"$adminSignInUrl\"" ]]; then
                       if [[ "$replayUrlsStr" != "" ]]; then
                           replayUrlsStr="$replayUrlsStr,"
                       fi
@@ -73,7 +68,7 @@ jobs:
 
               az rest --method PATCH --header "Content-Type=application/json" --uri $restUrl --body "{\"web\":{\"redirectUris\":[$replayUrlsStr]}}" #--debug
           else
-              echo "Reply URLs DOES NOT contains $existingUrl"
+              echo "Reply URLs DOES NOT contains $mediaSignInUrl and $adminSignInUrl"
           fi
 
         env:

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -76,7 +76,7 @@ jobs:
               restUrl="https://graph.microsoft.com/v1.0/applications/${objectId//[$'\t\r\n']/}"
               echo "Calling: $restUrl"
 
-              az rest --method PATCH --header "Content-Type=application/json" --uri $restUrl --body "{\"web\":{\"redirectUris\":[$replayUrlsStr]}}" #--debug
+              az rest --method PATCH --header "Content-Type=application/json" --uri $restUrl --body "{\"web\":{\"redirectUris\":[$replayUrlsStr]}}" --debug
 
           if [[ "${replyUrls}" =~ "${adminSignInUrl}" ]]; then
               echo "Reply URLs contains $adminSignInUrl"
@@ -103,7 +103,7 @@ jobs:
               restUrl="https://graph.microsoft.com/v1.0/applications/${objectId//[$'\t\r\n']/}"
               echo "Calling: $restUrl"
 
-              az rest --method PATCH --header "Content-Type=application/json" --uri $restUrl --body "{\"web\":{\"redirectUris\":[$replayUrlsStr]}}" #--debug
+              az rest --method PATCH --header "Content-Type=application/json" --uri $restUrl --body "{\"web\":{\"redirectUris\":[$replayUrlsStr]}}" --debug
           fi
 
         env:

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -51,31 +51,36 @@ jobs:
           echo "Found Reply URLs"
           echo $replyUrls
 
-          if [[ "${replyUrls}" =~ "${mediaSignInUrl}" ]]; then
-              echo "Reply URLs contains $mediaSignInUrl and $adminSignInUrl"
+          if [[ "${replyUrls}" =~ "${mediaSignInUrl}" && "${replyUrls}" =~ "${adminSignInUrl}" ]]; then
+            echo "Reply URLs contain $mediaSignInUrl and $adminSignInUrl"
           elif [ -z $replyUrls ]; then
-              echo "Not Reply URLs Found. ISSUE!!"
+            echo "No Reply URLs Found. ISSUE!!"
           else
-              echo "Reply URLs DOES NOT contain $mediaSignInUrl and $adminSignInUrl"
-              echo "Adding domains $mediaSignInUrl and $adminSignInUrl"
-              replayUrlsStr="\"$mediaSignInUrl\""$adminSignInUrl\""
-              readarray -t my_array < <(echo "$replyUrls" | jq -c '.[]')
+            readarray -t my_array < <(echo "$replyUrls" | jq -c '.[]')
+            for item in "${my_array[@]}"; do
+              echo "Url: $item"
+              replyUrlString+="$item,"
+            done
+    
+            if [[ ! "${replyUrls}" =~ "${mediaSignInUrl}" ]]; then
+              replyUrlString+="\"$mediaSignInUrl\""
+            fi
 
-              # iterate through the Bash array
-              for item in "${my_array[@]}"; do
-                  echo "Url: $item"
-                  replayUrlsStr="$replayUrlsStr, $item"
-              done
-              echo "reply String: $replayUrlsStr"
+            if [[ ! "${replyUrls}" =~ "${adminSignInUrl}" ]]; then
+              if [[ ! ${replyUrlString: -1} == "," ]]; then
+                replyUrlString+=","
+              fi
+              replyUrlString+="\"$adminSignInUrl\""
+            fi
 
-              objectId=$(az ad app list --all --filter "displayname eq '${targetAppName}'" --query "[0].id" -o tsv --only-show-errors)
-              objectId=${objectId//[$'\t\r\n']/}
-              echo "Object ID $objectId"
+            echo "reply String: $replyUrlString"
 
-              restUrl="https://graph.microsoft.com/v1.0/applications/${objectId//[$'\t\r\n']/}"
-              echo "Calling: $restUrl"
-
-              az rest --method PATCH --header "Content-Type=application/json" --uri $restUrl --body "{\"web\":{\"redirectUris\":[$replayUrlsStr]}}" #--debug
+            objectId=$(az ad app list --all --filter "displayname eq '${targetAppName}'" --query "[0].id" -o tsv --only-show-errors)
+            objectId=${objectId//[$'\t\r\n']/}
+            echo "Object ID $objectId"
+            restUrl="https://graph.microsoft.com/v1.0/applications/${objectId//[$'\t\r\n']/}"
+            echo "Calling: $restUrl"
+            az rest --method PATCH --header "Content-Type=application/json" --uri $restUrl --body "{\"web\":{\"redirectUris\":[$replyUrlString]}}" #--debug
           fi
 
         env:

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -9,7 +9,7 @@ on:
 permissions:
       id-token: write
       contents: read
-     
+
 jobs:
   deployment:
     runs-on: ubuntu-latest
@@ -20,16 +20,17 @@ jobs:
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID_STG }} 
-          
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID_STG }}
+
       - uses: Azure/get-keyvault-secrets@v1
-        with: 
+        with:
           keyvault: "pip-bootstrap-stg-kv"
           secrets: 'b2c-jenkins-tenant-id, b2c-jenkins-client-id, b2c-jenkins-client-secret'
         id: bootstrapKv
 
       - run: |
-          newUrl="https://pip-frontend-pr-${PR_NUMBER}.dev.platform.hmcts.net/login/return"
+          mediaSignInUrl="https://pip-frontend-pr-${PR_NUMBER}.dev.platform.hmcts.net/login/return"
+          adminSignInUrl="https://pip-frontend-pr-${PR_NUMBER}.dev.platform.hmcts.net/login/admin/return"
           targetAppName="pip-frontend-stg"
 
           azureClientId="${B2C_CLIENT_ID}"
@@ -50,14 +51,41 @@ jobs:
           echo "Found Reply URLs"
           echo $replyUrls
 
-          if [[ "${replyUrls}" =~ "${newUrl}" ]]; then
-              echo "Reply URLs contains $newUrl"
+          if [[ "${replyUrls}" =~ "${mediaSignInUrl}" ]]; then
+              echo "Reply URLs contains $mediaSignInUrl"
           elif [ -z $replyUrls ]; then
               echo "Not Reply URLs Found. ISSUE!!"
           else
-              echo "Reply URLs DOES NOT contains $newUrl"
-              echo "Adding domain $newUrl"
-              replayUrlsStr="\"$newUrl\""
+              echo "Reply URLs DOES NOT contains $mediaSignInUrl"
+              echo "Adding domain $mediaSignInUrl"
+              replayUrlsStr="\"$mediaSignInUrl\""
+
+              readarray -t my_array < <(echo "$replyUrls" | jq -c '.[]')
+
+              # iterate through the Bash array
+              for item in "${my_array[@]}"; do
+                  echo "Url: $item"
+                  replayUrlsStr="$replayUrlsStr, $item"
+              done
+              echo "reply String: $replayUrlsStr"
+
+              objectId=$(az ad app list --all --filter "displayname eq '${targetAppName}'" --query "[0].id" -o tsv --only-show-errors)
+              objectId=${objectId//[$'\t\r\n']/}
+              echo "Object ID $objectId"
+
+              restUrl="https://graph.microsoft.com/v1.0/applications/${objectId//[$'\t\r\n']/}"
+              echo "Calling: $restUrl"
+
+              az rest --method PATCH --header "Content-Type=application/json" --uri $restUrl --body "{\"web\":{\"redirectUris\":[$replayUrlsStr]}}" #--debug
+
+          if [[ "${replyUrls}" =~ "${adminSignInUrl}" ]]; then
+              echo "Reply URLs contains $adminSignInUrl"
+          elif [ -z $replyUrls ]; then
+              echo "Not Reply URLs Found. ISSUE!!"
+          else
+              echo "Reply URLs DOES NOT contains $adminSignInUrl"
+              echo "Adding domain $adminSignInUrl"
+              replayUrlsStr="\"$adminSignInUrl\""
 
               readarray -t my_array < <(echo "$replyUrls" | jq -c '.[]')
 

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -77,6 +77,7 @@ jobs:
 
               az rest --method PATCH --header "Content-Type=application/json" --uri $restUrl --body "{\"web\":{\"redirectUris\":[$replayUrlsStr]}}" #--debug
           fi
+          
         env:
           PR_NUMBER: ${{ github.event.number }}
           B2C_TENANT_ID: ${{ steps.bootstrapKv.outputs.b2c-jenkins-tenant-id }}

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -51,7 +51,7 @@ jobs:
           echo "Found Reply URLs"
           echo $replyUrls
 
-          if [[ "${replyUrls}" =~ "${mediaSignInUrl}" &&  "${replyUrls}" =~ "${adminSignInUrl}" ]]; then
+          if [[ "${replyUrls}" =~ "${mediaSignInUrl}" ]]; then
               echo "Reply URLs contains $mediaSignInUrl and $adminSignInUrl"
           elif [ -z $replyUrls ]; then
               echo "Not Reply URLs Found. ISSUE!!"
@@ -77,7 +77,7 @@ jobs:
 
               az rest --method PATCH --header "Content-Type=application/json" --uri $restUrl --body "{\"web\":{\"redirectUris\":[$replayUrlsStr]}}" #--debug
           fi
-          
+
         env:
           PR_NUMBER: ${{ github.event.number }}
           B2C_TENANT_ID: ${{ steps.bootstrapKv.outputs.b2c-jenkins-tenant-id }}

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -51,15 +51,14 @@ jobs:
           echo "Found Reply URLs"
           echo $replyUrls
 
-          if [[ "${replyUrls}" =~ "${mediaSignInUrl}" ]]; then
-              echo "Reply URLs contains $mediaSignInUrl"
+          if [[ "${replyUrls}" =~ "${mediaSignInUrl}" &&  "${replyUrls}" =~ "${adminSignInUrl}" ]]; then
+              echo "Reply URLs contains $mediaSignInUrl and $adminSignInUrl"
           elif [ -z $replyUrls ]; then
               echo "Not Reply URLs Found. ISSUE!!"
           else
-              echo "Reply URLs DOES NOT contains $mediaSignInUrl"
-              echo "Adding domain $mediaSignInUrl"
-              replayUrlsStr="\"$mediaSignInUrl\""
-
+              echo "Reply URLs DOES NOT contain $mediaSignInUrl and $adminSignInUrl"
+              echo "Adding domains $mediaSignInUrl and $adminSignInUrl"
+              replayUrlsStr="\"$mediaSignInUrl\""$adminSignInUrl\""
               readarray -t my_array < <(echo "$replyUrls" | jq -c '.[]')
 
               # iterate through the Bash array
@@ -78,35 +77,6 @@ jobs:
 
               az rest --method PATCH --header "Content-Type=application/json" --uri $restUrl --body "{\"web\":{\"redirectUris\":[$replayUrlsStr]}}" #--debug
           fi
-
-          if [[ "${replyUrls}" =~ "${adminSignInUrl}" ]]; then
-              echo "Reply URLs contains $adminSignInUrl"
-          elif [ -z $replyUrls ]; then
-              echo "Not Reply URLs Found. ISSUE!!"
-          else
-              echo "Reply URLs DOES NOT contains $adminSignInUrl"
-              echo "Adding domain $adminSignInUrl"
-              replayUrlsStr="\"$adminSignInUrl\""
-
-              readarray -t my_array < <(echo "$replyUrls" | jq -c '.[]')
-
-              # iterate through the Bash array
-              for item in "${my_array[@]}"; do
-                  echo "Url: $item"
-                  replayUrlsStr="$replayUrlsStr, $item"
-              done
-              echo "reply String: $replayUrlsStr"
-
-              objectId=$(az ad app list --all --filter "displayname eq '${targetAppName}'" --query "[0].id" -o tsv --only-show-errors)
-              objectId=${objectId//[$'\t\r\n']/}
-              echo "Object ID $objectId"
-
-              restUrl="https://graph.microsoft.com/v1.0/applications/${objectId//[$'\t\r\n']/}"
-              echo "Calling: $restUrl"
-
-              az rest --method PATCH --header "Content-Type=application/json" --uri $restUrl --body "{\"web\":{\"redirectUris\":[$replayUrlsStr]}}" #--debug
-          fi
-
         env:
           PR_NUMBER: ${{ github.event.number }}
           B2C_TENANT_ID: ${{ steps.bootstrapKv.outputs.b2c-jenkins-tenant-id }}

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -76,7 +76,8 @@ jobs:
               restUrl="https://graph.microsoft.com/v1.0/applications/${objectId//[$'\t\r\n']/}"
               echo "Calling: $restUrl"
 
-              az rest --method PATCH --header "Content-Type=application/json" --uri $restUrl --body "{\"web\":{\"redirectUris\":[$replayUrlsStr]}}" --debug
+              az rest --method PATCH --header "Content-Type=application/json" --uri $restUrl --body "{\"web\":{\"redirectUris\":[$replayUrlsStr]}}" #--debug
+          fi
 
           if [[ "${replyUrls}" =~ "${adminSignInUrl}" ]]; then
               echo "Reply URLs contains $adminSignInUrl"
@@ -103,7 +104,7 @@ jobs:
               restUrl="https://graph.microsoft.com/v1.0/applications/${objectId//[$'\t\r\n']/}"
               echo "Calling: $restUrl"
 
-              az rest --method PATCH --header "Content-Type=application/json" --uri $restUrl --body "{\"web\":{\"redirectUris\":[$replayUrlsStr]}}" --debug
+              az rest --method PATCH --header "Content-Type=application/json" --uri $restUrl --body "{\"web\":{\"redirectUris\":[$replayUrlsStr]}}" #--debug
           fi
 
         env:

--- a/charts/pip-frontend/Chart.yaml
+++ b/charts/pip-frontend/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for pip-frontend App
 name: pip-frontend
 home: https://github.com/hmcts/pip-frontend
-version: 0.0.35
+version: 0.0.36
 maintainers:
   - name: HMCTS PIP Team
 dependencies:

--- a/charts/pip-frontend/values.dev.template.yaml
+++ b/charts/pip-frontend/values.dev.template.yaml
@@ -7,5 +7,6 @@ nodejs:
   environment:
     OIDC: true
     AUTH_RETURN_URL: https://${SERVICE_FQDN}/login/return
+    ADMIN_AUTH_RETURN_URL: https://${SERVICE_FQDN}/login/admin/return
     FRONTEND_URL: https://${SERVICE_FQDN}
     EXCLUDE_E2E: true

--- a/charts/pip-frontend/values.stg.template.yaml
+++ b/charts/pip-frontend/values.stg.template.yaml
@@ -5,4 +5,5 @@ nodejs:
   environment:
     EXCLUDE_E2E: false
     AUTH_RETURN_URL: https://${SERVICE_FQDN}/login/return
+    ADMIN_AUTH_RETURN_URL: https://${SERVICE_FQDN}/login/admin/return
     FRONTEND_URL: https://${SERVICE_FQDN}

--- a/charts/pip-frontend/values.yaml
+++ b/charts/pip-frontend/values.yaml
@@ -7,6 +7,7 @@ nodejs:
   environment:
     OIDC: true
     AUTH_RETURN_URL: https://127.0.0.1/login/return
+    ADMIN_AUTH_RETURN_URL: https://127.0.0.1/login/admin/return
   keyVaults:
     pip-ss-kv:
       resourceGroup: pip-ss-{{ .Values.global.environment }}-rg

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,5 +6,5 @@ sonar.sources=src/main
 sonar.tests=src/test
 sonar.test.exclusions=test/coverage/**
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
-sonar.exclusions=src/main/app.ts,src/main/development.ts,src/main/index.js,src/main/server.ts,src/main/modules/i18next/index.ts,src/main/bundles/cookie-preferences.ts,src/main/modules/helmet/index.ts
+sonar.exclusions=src/main/app.ts,src/main/development.ts,src/main/index.js,src/main/server.ts,src/main/modules/i18next/index.ts,src/main/bundles/cookie-preferences.ts,src/main/modules/helmet/index.ts,src/main/routes/routes.ts
 

--- a/src/main/authentication/authentication.ts
+++ b/src/main/authentication/authentication.ts
@@ -44,6 +44,7 @@ function oidcSetup(): void {
   logger.info('secret', clientSecret ? clientSecret.substring(0,5) : 'client secret not set!' );
 
   const AUTH_RETURN_URL = process.env.AUTH_RETURN_URL || 'https://pip-frontend.staging.platform.hmcts.net/login/return';
+  const ADMIN_AUTH_RETURN_URL = process.env.ADMIN_AUTH_RETURN_URL || 'https://pip-frontend.staging.platform.hmcts.net/login/admin/return';
   const users = [];
 
   const findByOid = async function(oid, fn): Promise<any> {
@@ -96,7 +97,7 @@ function oidcSetup(): void {
     clientID: clientId,
     responseType: authenticationConfig.RESPONSE_TYPE,
     responseMode: authenticationConfig.RESPONSE_MODE,
-    redirectUrl: AUTH_RETURN_URL,
+    redirectUrl: ADMIN_AUTH_RETURN_URL,
     allowHttpForRedirectUrl: true,
     clientSecret: clientSecret,
     isB2C: true,

--- a/src/main/authentication/authenticationHandler.ts
+++ b/src/main/authentication/authenticationHandler.ts
@@ -67,10 +67,16 @@ export function checkAuthenticatedMedia(req: any, res, next, roles: string[]): b
 
 export function forgotPasswordRedirect(req, res, next): void {
   const body = JSON.stringify(req.body);
+
   if (body.includes('AADB2C90118')) {
+    let REDIRECT_URL = `${FRONTEND_URL}/password-change-confirmation`;
+    if(req.originalUrl === '/login/admin/return') {
+      REDIRECT_URL += '/true';
+    } else {
+      REDIRECT_URL += '/false';
+    }
     const CLIENT_ID = config.get('secrets.pip-ss-kv.CLIENT_ID');
     const B2C_URL = config.get('secrets.pip-ss-kv.B2C_URL');
-    const REDIRECT_URL = `${FRONTEND_URL}/password-change-confirmation`;
     const POLICY_URL = `${B2C_URL}/oauth2/v2.0/authorize?p=${authenticationConfig.FORGOT_PASSWORD_POLICY}` +
     `&client_id=${CLIENT_ID}&nonce=defaultNonce&redirect_uri=${REDIRECT_URL}` +
     '&scope=openid&response_type=id_token&prompt=login';

--- a/src/main/controllers/AdminRejectedLoginController.ts
+++ b/src/main/controllers/AdminRejectedLoginController.ts
@@ -1,0 +1,8 @@
+import { Response } from 'express';
+import { PipRequest } from '../models/request/PipRequest';
+
+export default class AdminRejectedLoginController {
+  public get(req: PipRequest, res: Response): void {
+    res.render('admin-rejected-login', req.i18n.getDataByLanguage(req.lng)['admin-rejected-login']);
+  }
+}

--- a/src/main/controllers/PasswordChangeController.ts
+++ b/src/main/controllers/PasswordChangeController.ts
@@ -1,8 +1,17 @@
 import { Response } from 'express';
 import { PipRequest } from '../models/request/PipRequest';
+import {cloneDeep} from 'lodash';
 
 export default class PasswordChangeController {
   public get(req: PipRequest, res: Response): void {
-    res.render('password-change-confirmation', req.i18n.getDataByLanguage(req.lng)['password-change-confirmation']);
+    const splitUrl = req.path.split('/')[2];
+    let isAdmin = false;
+    if(splitUrl === 'true') {
+      isAdmin = true;
+    }
+    res.render('password-change-confirmation', {
+      ...cloneDeep(req.i18n.getDataByLanguage(req.lng)['password-change-confirmation']),
+      isAdmin: isAdmin,
+    });
   }
 }

--- a/src/main/resources/locales/en/admin-rejected-login.json
+++ b/src/main/resources/locales/en/admin-rejected-login.json
@@ -1,0 +1,6 @@
+{
+  "header": "Sign in rejected",
+  "bodyText1": "You have attempted to login following the wrong process.",
+  "bodyText2": "Please click the button below to sign in through the admin process.",
+  "buttonText": "Sign in"
+}

--- a/src/main/routes/routes.ts
+++ b/src/main/routes/routes.ts
@@ -91,11 +91,14 @@ export default function(app: Application): void {
   app.get('/daily-cause-list', app.locals.container.cradle.dailyCauseListController.get);
   app.get('/family-daily-cause-list', app.locals.container.cradle.dailyCauseListController.get);
   app.get('/hearing-list', app.locals.container.cradle.hearingListController.get);
-  app.get('/password-change-confirmation', app.locals.container.cradle.passwordChangeController.get);
+  app.get('/password-change-confirmation/:isAdmin', app.locals.container.cradle.passwordChangeController.get);
+  app.get('/admin-rejected-login', app.locals.container.cradle.adminRejectedLoginController.get);
   app.get('/login', passport.authenticate('login', { failureRedirect: '/'}), regenerateSession);
   app.get('/admin-login', passport.authenticate('admin-login', { failureRedirect: '/'}), regenerateSession);
   app.post('/login/return', forgotPasswordRedirect, passport.authenticate('login', { failureRedirect: '/view-option'}),
-    (_req, res) => {checkRoles(_req, allAdminRoles) ? res.redirect('/admin-dashboard') : res.redirect('/account-home');});
+    (_req, res) => {checkRoles(_req, allAdminRoles) ? logOut(_req, res, `${FRONTEND_URL}/admin-rejected-login`) : res.redirect('/account-home');});
+  app.post('/login/admin/return', forgotPasswordRedirect, passport.authenticate('admin-login', { failureRedirect: '/view-option'}),
+    (_req, res) => {checkRoles(_req, allAdminRoles) ? res.redirect('/admin-dashboard') : res.redirect('/view-option');});
   app.get('/logout', (_req, res) => {checkRoles(_req, allAdminRoles) ?
     logOut(_req, res, `${FRONTEND_URL}/login?p=`+ authenticationConfig.ADMIN_POLICY) : logOut(_req, res, `${FRONTEND_URL}/view-option`);});
   app.get('/live-case-alphabet-search', app.locals.container.cradle.liveCaseCourtSearchController.get);

--- a/src/main/views/admin-rejected-login.njk
+++ b/src/main/views/admin-rejected-login.njk
@@ -14,16 +14,11 @@
 {% endblock %}
 {% block content %}
   <h1 class="govuk-heading-l">{{ header }}</h1>
-  <p class="govuk-body">{{ bodyText }}</p>
-  {% if isAdmin %}
-    {% set flow = "/admin-login?p=B2C_1_SignInAdminUserFlow" %}
-  {% else %}
-    {% set flow = "/login?p=B2C_1_SignInUserFlow" %}
-  {% endif %}
-
+  <p class="govuk-body">{{ bodyText1 }}</p>
+  <p class="govuk-body">{{ bodyText2 }}</p>
   {{ govukButton({
     id: 'buttonForSignIn',
     text: buttonText,
-    href: flow
+    href: '/admin-login?p=B2C_1_SignInAdminUserFlow'
   }) }}
 {% endblock %}

--- a/src/test/a11y/a11y.ts
+++ b/src/test/a11y/a11y.ts
@@ -24,6 +24,7 @@ const routesNotTested = [
   '/login',
   '/admin-login',
   '/login/return',
+  '/login/admin/return',
   '/mock-login',
   '/logout',
   '/robots.txt',

--- a/src/test/routes/admin-rejected-login.test.ts
+++ b/src/test/routes/admin-rejected-login.test.ts
@@ -1,0 +1,14 @@
+import { expect } from 'chai';
+import request from 'supertest';
+
+import { app } from '../../main/app';
+
+describe('Admin rejected login page', () => {
+  describe('on GET', () => {
+    test('should return admin-rejected-login page', async () => {
+      await request(app)
+        .get('/admin-rejected-login')
+        .expect((res) => expect(res.status).to.equal(200));
+    });
+  });
+});

--- a/src/test/routes/login.test.ts
+++ b/src/test/routes/login.test.ts
@@ -13,4 +13,10 @@ describe('Login', () => {
       .post('/login/return')
       .expect((res) => expect(res.redirect).toBeTruthy());
   });
+
+  test('should redirect to the admin dashboard page on return', async() => {
+    await request(app)
+      .post('/login/admin/return')
+      .expect((res) => expect(res.redirect).toBeTruthy());
+  });
 });

--- a/src/test/routes/password-change-confirmation.test.ts
+++ b/src/test/routes/password-change-confirmation.test.ts
@@ -5,9 +5,15 @@ import { app } from '../../main/app';
 
 describe('Password Change Confirmation Page', () => {
   describe('on GET', () => {
-    test('should return password-change-confirmation page', async () => {
+    test('should return password-change-confirmation page for media', async () => {
       await request(app)
-        .get('/password-change-confirmation')
+        .get('/password-change-confirmation/false')
+        .expect((res) => expect(res.status).to.equal(200));
+    });
+
+    test('should return password-change-confirmation page for admin', async () => {
+      await request(app)
+        .get('/password-change-confirmation/true')
         .expect((res) => expect(res.status).to.equal(200));
     });
   });

--- a/src/test/unit/authentication/Authentication.test.ts
+++ b/src/test/unit/authentication/Authentication.test.ts
@@ -38,7 +38,7 @@ describe('Authentication', () => {
       .to.eql('https://pip-frontend.staging.platform.hmcts.net/login/return');
     expect(passport._strategies['admin-login'].name).to.eql('azuread-openidconnect');
     expect(passport._strategies['admin-login']._options.redirectUrl)
-      .to.eql('https://pip-frontend.staging.platform.hmcts.net/login/return');
+      .to.eql('https://pip-frontend.staging.platform.hmcts.net/login/admin/return');
   });
 
   it('Should set up passport correctly for azure authentication when FRONTEND_URL is set', () => {
@@ -55,7 +55,7 @@ describe('Authentication', () => {
       .to.eql('https://pip-frontend.staging.platform.hmcts.net/login/return');
     expect(passport._strategies['admin-login'].name).to.eql('azuread-openidconnect');
     expect(passport._strategies['admin-login']._options.redirectUrl)
-      .to.eql('https://pip-frontend.staging.platform.hmcts.net/login/return');
+      .to.eql('https://pip-frontend.staging.platform.hmcts.net/login/admin/return');
   });
 
   parameters.forEach((parameter) => {

--- a/src/test/unit/authentication/authenticationHandler.test.ts
+++ b/src/test/unit/authentication/authenticationHandler.test.ts
@@ -220,11 +220,20 @@ describe('Test IsPermittedMediaAccount', () => {
 });
 
 describe('forgot password reset', () => {
-  test('should redirect to azure again if password reset error is returned from the B2C', async () => {
+  test('should redirect to azure again if password reset error is returned from the B2C with the correct media redirect url', async () => {
     await request(app)
       .post('/login/return')
       .send({'error': 'access_denied', 'error_description': 'AADB2C90118'})
-      .expect((res) => expect(res.redirect).to.be.true);
+      .expect((res) => expect(res.redirect).to.be.true)
+      .expect((res) => expect(res.header.location).to.contain('/password-change-confirmation/false'));
+  });
+
+  test('should redirect to azure again if password reset error is returned from the B2C with the correct admin redirect url', async () => {
+    await request(app)
+      .post('/login/admin/return')
+      .send({'error': 'access_denied', 'error_description': 'AADB2C90118'})
+      .expect((res) => expect(res.redirect).to.be.true)
+      .expect((res) => expect(res.header.location).to.contain('/password-change-confirmation/true'));
   });
 });
 

--- a/src/test/unit/controllers/AdminRejectedLoginController.test.ts
+++ b/src/test/unit/controllers/AdminRejectedLoginController.test.ts
@@ -1,0 +1,28 @@
+import { mockRequest } from '../mocks/mockRequest';
+import { Response } from 'express';
+import sinon from 'sinon';
+import AdminRejectedLoginController from '../../../main/controllers/AdminRejectedLoginController';
+
+const adminRejectedLoginController = new AdminRejectedLoginController();
+
+describe('Admin rejected login controller', () => {
+  const response = { render: () => {return '';}} as unknown as Response;
+  const request = mockRequest({'admin-rejected-login': {}});
+
+  it('should render admin-rejected-login', async () => {
+    const responseMock = sinon.mock(response);
+
+    const i18n = {
+      'admin-rejected-login': {},
+    };
+
+    const expectedData = {
+      ...i18n['admin-rejected-login'],
+    };
+
+    responseMock.expects('render').once().withArgs('admin-rejected-login', expectedData);
+
+    await adminRejectedLoginController.get(request, response);
+    await responseMock.verify();
+  });
+});

--- a/src/test/unit/controllers/PasswordChangeController.test.ts
+++ b/src/test/unit/controllers/PasswordChangeController.test.ts
@@ -6,12 +6,43 @@ import PasswordChangeController from '../../../main/controllers/PasswordChangeCo
 const passwordChangeController = new PasswordChangeController();
 
 describe('Password Change Confirmation controller', () => {
-  it('should render password-change-confirmation', async () => {
-    const response = { render: () => {return '';}} as unknown as Response;
-    const request = mockRequest({'password-change-confirmation': {}});
+  const response = { render: () => {return '';}} as unknown as Response;
+  const request = mockRequest({'password-change-confirmation': {}});
+
+  it('should render password-change-confirmation for an admin', async () => {
+    request.path = '/password-change-confirmation/true';
     const responseMock = sinon.mock(response);
 
-    responseMock.expects('render').once().withArgs('password-change-confirmation', request.i18n.getDataByLanguage(request.lng)['password-change-confirmation']);
+    const i18n = {
+      'password-change-confirmation': {},
+    };
+
+    const expectedData = {
+      ...i18n['password-change-confirmation'],
+      isAdmin: true,
+    };
+
+    responseMock.expects('render').once().withArgs('password-change-confirmation', expectedData);
+
+    await passwordChangeController.get(request, response);
+    await responseMock.verify();
+  });
+
+  it('should render password-change-confirmation for a media user', async () => {
+    request.path = '/password-change-confirmation/false';
+    const responseMock = sinon.mock(response);
+
+    const i18n = {
+      'password-change-confirmation': {},
+    };
+
+    const expectedData = {
+      ...i18n['password-change-confirmation'],
+      isAdmin: false,
+    };
+
+    responseMock.expects('render').once().withArgs('password-change-confirmation', expectedData);
+
     await passwordChangeController.get(request, response);
     await responseMock.verify();
   });

--- a/src/test/unit/views/admin-rejected-login.test.ts
+++ b/src/test/unit/views/admin-rejected-login.test.ts
@@ -1,0 +1,35 @@
+import { expect } from 'chai';
+import request from 'supertest';
+
+import { app } from '../../../main/app';
+const largeHeadingClass = 'govuk-heading-l';
+
+let htmlRes: Document;
+
+describe('Admin rejected login page', () => {
+  beforeAll(async () => {
+    const PAGE_URL = '/admin-rejected-login';
+    await request(app).get(PAGE_URL).then(res => {
+      htmlRes = new DOMParser().parseFromString(res.text, 'text/html');
+    });
+  });
+
+  it('should display the page header', () => {
+    const header = htmlRes.getElementsByClassName(largeHeadingClass);
+    expect(header[0].innerHTML).contains('Sign in rejected', 'Could not find the header');
+  });
+
+  it('should display the body text', () => {
+    const bodyText = htmlRes.getElementsByClassName('govuk-body');
+    expect(bodyText[4].innerHTML).contains('You have attempted to login following the wrong process.',
+      'Could not find body text');
+    expect(bodyText[5].innerHTML).contains('Please click the button below to sign in through the admin process.',
+      'Could not find body text');
+  });
+
+  it('should display the button', () => {
+    const button = htmlRes.getElementsByClassName('govuk-button');
+    expect(button[4].textContent).contains('Sign in', 'Could not find button');
+    expect(button[4].outerHTML).contains('B2C_1_SignInAdminUserFlow');
+  });
+});

--- a/src/test/unit/views/password-change-confirmation.test.ts
+++ b/src/test/unit/views/password-change-confirmation.test.ts
@@ -2,33 +2,50 @@ import { expect } from 'chai';
 import request from 'supertest';
 
 import { app } from '../../../main/app';
-
-const PAGE_URL = '/password-change-confirmation';
 const largeHeadingClass = 'govuk-heading-l';
 
 let htmlRes: Document;
 
 describe('password-change-confirmation', () => {
-  beforeAll(async () => {
-    await request(app).get(PAGE_URL).then(res => {
-      htmlRes = new DOMParser().parseFromString(res.text, 'text/html');
+
+  describe('Admin user', () => {
+    beforeAll(async () => {
+      const PAGE_URL = '/password-change-confirmation/true';
+      await request(app).get(PAGE_URL).then(res => {
+        htmlRes = new DOMParser().parseFromString(res.text, 'text/html');
+      });
+    });
+
+    it('should display the page header', () => {
+      const header = htmlRes.getElementsByClassName(largeHeadingClass);
+      expect(header[0].innerHTML).contains('Password changed successfully', 'Could not find the header');
+    });
+
+    it('should display the body text', () => {
+      const bodyText = htmlRes.getElementsByClassName('govuk-body');
+      expect(bodyText[4].innerHTML).contains('You can now sign in with your new credentials using the button below.',
+        'Could not find body text');
+    });
+
+    it('should display the button', () => {
+      const button = htmlRes.getElementsByClassName('govuk-button');
+      expect(button[4].textContent).contains('Sign in', 'Could not find button');
+      expect(button[4].outerHTML).contains('B2C_1_SignInAdminUserFlow');
     });
   });
 
-  it('should display the page header', () => {
-    const header = htmlRes.getElementsByClassName(largeHeadingClass);
-    expect(header[0].innerHTML).contains('Password changed successfully', 'Could not find the header');
-  });
+  describe('Media user', () => {
+    beforeAll(async () => {
+      const PAGE_URL = '/password-change-confirmation/false';
+      await request(app).get(PAGE_URL).then(res => {
+        htmlRes = new DOMParser().parseFromString(res.text, 'text/html');
+      });
+    });
 
-  it('should display the body text', () => {
-    const bodyText = htmlRes.getElementsByClassName('govuk-body');
-    expect(bodyText[4].innerHTML).contains('You can now sign in with your new credentials using the button below.',
-      'Could not find body text');
-  });
-
-  it('should display the button', () => {
-    const button = htmlRes.getElementsByClassName('govuk-button');
-    expect(button[4].textContent).contains('Sign in', 'Could not find button');
-    expect(button[4].outerHTML).contains('B2C_1_SignInUserFlow');
+    it('should display the button', () => {
+      const button = htmlRes.getElementsByClassName('govuk-button');
+      expect(button[4].textContent).contains('Sign in', 'Could not find button');
+      expect(button[4].outerHTML).contains('B2C_1_SignInUserFlow');
+    });
   });
 });


### PR DESCRIPTION
### JIRA link ###

https://tools.hmcts.net/jira/browse/PUB-1432

### Change description ###

- Added new return URL for the admin flow
- Added new handling for if an admin user attempts sign in through the media flow
- Added new admin rejection page for any admins that sign in incorrectly
- Updated password confirmation page to give correct href in the button based off the flow the user selected the password reset through
- Updated GitHub actions to create the return URLs on PR opening

Note: admin rejection page wording needs to be confirmed

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
