### PR TITLE
Updated display to date for E2Es

### DIFF
--- a/src/test/e2e/PageObjects/ManualUpload.page.ts
+++ b/src/test/e2e/PageObjects/ManualUpload.page.ts
@@ -89,7 +89,7 @@ export class ManualUploadPage extends CommonPage {
 
     await $(helpers.displayDateToDay).addValue('01');
     await $(helpers.displayDateToMonth).addValue('01');
-    await $(helpers.displayDateToYear).addValue('2022');
+    await $(helpers.displayDateToYear).addValue('2024');
   }
 
   async clickContinue(): Promise<ManualUploadSummaryPage> {


### PR DESCRIPTION
### Change description ###

Updated the display to date for E2Es so we don't run out of publications for the tests.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
