### PR TITLE
PUB-1893 - Added null check

### DIFF
--- a/src/main/controllers/FlatFileController.ts
+++ b/src/main/controllers/FlatFileController.ts
@@ -9,14 +9,19 @@ export default class FlatFileController {
         const artefactId = req.query['artefactId'];
         const metadata = await publicationService.getIndividualPublicationMetadata(artefactId, req.user?.['userId']);
         const fileData = await publicationService.getIndividualPublicationFile(artefactId, req.user?.['userId']);
-        res.set('Content-Disposition', 'inline;filename=' + metadata.sourceArtefactId);
-        if (metadata.sourceArtefactId.endsWith('.pdf')) {
-            res.set('Content-Type', 'application/pdf');
-        } else if (metadata.sourceArtefactId.endsWith('.json')) {
-            res.set('Content-Type', 'application/json');
+
+        if (metadata && fileData && metadata.sourceArtefactId) {
+            res.set('Content-Disposition', 'inline;filename=' + metadata.sourceArtefactId);
+            if (metadata.sourceArtefactId.endsWith('.pdf')) {
+                res.set('Content-Type', 'application/pdf');
+            } else if (metadata.sourceArtefactId.endsWith('.json')) {
+                res.set('Content-Type', 'application/json');
+            } else {
+                res.set('Content-Disposition', 'attachment;filename=' + metadata.sourceArtefactId);
+            }
+            res.send(fileData);
         } else {
-            res.set('Content-Disposition', 'attachment;filename=' + metadata.sourceArtefactId);
+            res.render('error', req.i18n.getDataByLanguage(req.lng).error);
         }
-        res.send(fileData);
     }
 }

--- a/src/test/unit/controllers/FlatFileController.test.ts
+++ b/src/test/unit/controllers/FlatFileController.test.ts
@@ -16,6 +16,9 @@ const response = {
     set: function () {
         return '';
     },
+    render: function () {
+        return '';
+    },
 } as unknown as Response;
 
 describe('Flat File Controller', () => {
@@ -53,6 +56,48 @@ describe('Flat File Controller', () => {
         request.user = { userId: '1' };
         const responseMock = sinon.mock(response);
         responseMock.expects('send').once().withArgs(mockFile);
+        return flatFileController.get(request, response).then(() => {
+            responseMock.verify();
+        });
+    });
+
+    it('should render error page when meta is null', () => {
+        metaStub.withArgs('0').resolves(null);
+        fileStub.withArgs('0').resolves(mockFile);
+        const request = mockRequest(i18n);
+        request.query = { artefactId: '0' };
+        request.user = { userId: '1' };
+        const responseMock = sinon.mock(response);
+
+        responseMock.expects('render').once().withArgs('error', request.i18n.getDataByLanguage(request.lng).error);
+        return flatFileController.get(request, response).then(() => {
+            responseMock.verify();
+        });
+    });
+
+    it('should render error page when file is null', () => {
+        metaStub.withArgs('0').resolves({ isFlatFile: 'true', sourceArtefactId: 'doc.pdf' });
+        fileStub.withArgs('0').resolves(null);
+        const request = mockRequest(i18n);
+        request.query = { artefactId: '0' };
+        request.user = { userId: '1' };
+        const responseMock = sinon.mock(response);
+
+        responseMock.expects('render').once().withArgs('error', request.i18n.getDataByLanguage(request.lng).error);
+        return flatFileController.get(request, response).then(() => {
+            responseMock.verify();
+        });
+    });
+
+    it('should render error page when source artefact ID does not exist in metadata', () => {
+        metaStub.withArgs('0').resolves({ isFlatFile: 'true' });
+        fileStub.withArgs('0').resolves(mockFile);
+        const request = mockRequest(i18n);
+        request.query = { artefactId: '0' };
+        request.user = { userId: '1' };
+        const responseMock = sinon.mock(response);
+
+        responseMock.expects('render').once().withArgs('error', request.i18n.getDataByLanguage(request.lng).error);
         return flatFileController.get(request, response).then(() => {
             responseMock.verify();
         });


### PR DESCRIPTION
### JIRA link

https://tools.hmcts.net/jira/browse/PUB-1893

### Change description

Added a null check on Flat File download to ensure that metadata, the file and source artefact ID are all present. 

If they are not present, it will re-direct to the error page.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
