### PR TITLE
PUB-2074 Redis with ping

### DIFF
--- a/src/main/cacheManager.ts
+++ b/src/main/cacheManager.ts
@@ -30,7 +30,7 @@ const redisClient = new ioRedis(connectionString, { connectTimeout: 10000 });
 //does not work with Azure. ioredis does not include an in build ping process, therefore need to implement our own.
 setInterval(() => {
     redisClient.ping();
-}, 300000)
+}, 300000);
 
 /* istanbul ignore next */
 if (!process.env.REDIS_SUPPRESS) {

--- a/src/main/cacheManager.ts
+++ b/src/main/cacheManager.ts
@@ -26,6 +26,12 @@ if (process.env.REDIS_LOCAL) {
 }
 const redisClient = new ioRedis(connectionString, { connectTimeout: 10000 });
 
+//This is required due to azure removing idle connections after 10 minutes. Unfortunately the KEEPALIVE option
+//does not work with Azure. ioredis does not include an in build ping process, therefore need to implement our own.
+setInterval(() => {
+    redisClient.ping();
+}, 300000)
+
 /* istanbul ignore next */
 if (!process.env.REDIS_SUPPRESS) {
     logger.info('redis env var', redisCredentials.host);


### PR DESCRIPTION
### JIRA link

https://tools.hmcts.net/jira/browse/PUB-2074

### Change description

Added a ping for Redis, to keep the connection alive.

IORedis does not have a ping features (it's an open issue), and Azure does not work with the TLS Keep Alive option, therefore a manual ping is required.

This has been set for every 5 minutes

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
