### PR TITLE
PUB-2242 - Updated bulk unsubscribe page with correct text

### DIFF
--- a/src/main/resources/locales/cy/bulk-unsubscribe-confirmed.json
+++ b/src/main/resources/locales/cy/bulk-unsubscribe-confirmed.json
@@ -1,6 +1,5 @@
 {
-    "title": "Tanysgrifiad wedi’i ddileu/Tanysgrifiadau wedi’u dileu",
-    "message": "Mae eich tanysgrifiad wedi’i ddileu/tanysgrifiadau wedi’u dileu.",
+    "title": "Tanysgrifiadau e-bost wedi’u diweddaru",
     "pStart": "I barhau, gallwch fynd i’ch",
     "pEnd": "i:",
     "yourAccount": "cyfrif",

--- a/src/main/resources/locales/en/bulk-unsubscribe-confirmed.json
+++ b/src/main/resources/locales/en/bulk-unsubscribe-confirmed.json
@@ -1,6 +1,5 @@
 {
-    "title": "Subscription(s) removed",
-    "message": "Your subscription(s) has been removed.",
+    "title": "Email subscriptions updated",
     "pStart": "To continue, you can go to",
     "pEnd": "in order to:",
     "yourAccount": "your account",

--- a/src/main/views/bulk-unsubscribe-confirmed.njk
+++ b/src/main/views/bulk-unsubscribe-confirmed.njk
@@ -12,7 +12,7 @@
 {% endblock %}
 
 {% block content %}
-  {{ successPanel(title, message) }}
+  {{ successPanel(title) }}
   <div class="parent-box">
     <p class="govuk-body">
       {{ pStart }}

--- a/src/test/end-to-end/tests/verified/email-subscriptions-test.ts
+++ b/src/test/end-to-end/tests/verified/email-subscriptions-test.ts
@@ -193,8 +193,7 @@ Scenario(
         I.waitForText('Are you sure you want to bulk unsubscribe the above selection?');
         I.click('#bulk-unsubscribe-choice');
         I.click('Continue');
-        I.waitForText('Subscription(s) removed');
-        I.see('Your subscription(s) has been removed.');
+        I.waitForText('Email subscriptions updated');
         I.logout();
     }
 ).tag('@CrossBrowser');
@@ -295,7 +294,7 @@ Scenario(
         I.waitForText('Are you sure you want to bulk unsubscribe the above selection?');
         I.click('#bulk-unsubscribe-choice');
         I.click('Continue');
-        I.waitForText('Subscription(s) removed');
+        I.waitForText('Email subscriptions updated');
         I.logout();
     }
 ).tag('@Nightly');

--- a/src/test/unit/views/bulk-unsubscribe-confirmed.test.ts
+++ b/src/test/unit/views/bulk-unsubscribe-confirmed.test.ts
@@ -19,7 +19,7 @@ describe('Bulk Unsubscribe Confirmed Page', () => {
 
     it('should have correct page title', () => {
         const pageTitle = htmlRes.title;
-        expect(pageTitle).contains('Subscription(s) removed', 'Page title does not match header');
+        expect(pageTitle).contains('Email subscriptions updated', 'Page title does not match header');
     });
 
     it('should display confirmation panel component', () => {
@@ -30,8 +30,8 @@ describe('Bulk Unsubscribe Confirmed Page', () => {
     it('should display confirmation within the panel', () => {
         const panelTitle = htmlRes.getElementsByClassName('govuk-panel__title');
         const panelMessage = htmlRes.getElementsByClassName('govuk-panel__body');
-        expect(panelTitle[0].innerHTML).to.contains('Subscription(s) removed');
-        expect(panelMessage[0].innerHTML).to.contains('Your subscription(s) has been removed');
+        expect(panelTitle[0].innerHTML).to.contains('Email subscriptions updated');
+        expect(panelMessage[0]).to.be.undefined;
     });
 
     it('should contain you account url', () => {


### PR DESCRIPTION
### JIRA link

https://tools.hmcts.net/jira/browse/PUB-2242

### Change description

Updated bulk unsubscribe text

![image](https://github.com/hmcts/pip-frontend/assets/87066931/828d033c-4125-455c-bfa1-2681a41992b9)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
