### PR TITLE
PUB-2286 Return empty array for courts when data-management is down

### DIFF
--- a/src/main/resources/requests/locationRequests.ts
+++ b/src/main/resources/requests/locationRequests.ts
@@ -40,7 +40,7 @@ export class LocationRequests {
         } catch (error) {
             logHelper.logErrorResponse(error, 'retrieve filtered locations');
         }
-        return null;
+        return [];
     }
 
     public async getAllLocations(): Promise<Array<Location>> {
@@ -50,7 +50,7 @@ export class LocationRequests {
         } catch (error) {
             logHelper.logErrorResponse(error, 'retrieve all locations');
         }
-        return null;
+        return [];
     }
 
     public async deleteCourt(locationId: number, adminUserId: string): Promise<object> {

--- a/src/test/unit/requests/locationRequests.test.ts
+++ b/src/test/unit/requests/locationRequests.test.ts
@@ -176,41 +176,41 @@ describe('Location get requests', () => {
         expect(await courtRequests.getFilteredCourts(regions, jurisdictions, englishLanguage)).toBe(courtList);
     });
 
-    it('should return null if response fails', async () => {
-        expect(await courtRequests.getFilteredCourts(test, 'error', englishLanguage)).toBe(null);
+    it('should return empty array if response fails', async () => {
+        expect(await courtRequests.getFilteredCourts(test, 'error', englishLanguage)).toStrictEqual([]);
     });
 
     it('should return Welsh list of courts based on search filter', async () => {
         expect(await courtRequests.getFilteredCourts(welshRegions, welshJurisdictions, welshLanguage)).toBe(courtList);
     });
 
-    it('should return null if Welsh request fails', async () => {
-        expect(await courtRequests.getFilteredCourts(test, test, welshLanguage)).toBe(null);
+    it('should return empty array if Welsh request fails', async () => {
+        expect(await courtRequests.getFilteredCourts(test, test, welshLanguage)).toStrictEqual([]);
     });
 
-    it('should return null if Welsh response fails', async () => {
-        expect(await courtRequests.getFilteredCourts(test, 'error', welshLanguage)).toBe(null);
+    it('should return empty array if Welsh response fails', async () => {
+        expect(await courtRequests.getFilteredCourts(test, 'error', welshLanguage)).toStrictEqual([]);
     });
 
     it('should return list of courts', async () => {
         expect(await courtRequests.getAllLocations()).toBe(courtList);
     });
 
-    it('should return null list of courts for error response', async () => {
+    it('should return empty list of courts for error response', async () => {
         stub.withArgs('/locations').rejects(errorResponse);
-        expect(await courtRequests.getFilteredCourts(test, test, englishLanguage)).toBe(null);
+        expect(await courtRequests.getFilteredCourts(test, test, englishLanguage)).toStrictEqual([]);
     });
 
-    it('should return null list of courts for errored call', async () => {
+    it('should return empty list of courts for errored call', async () => {
         stub.withArgs('/locations').rejects(errorMessage);
         stub.withArgs('allCourts').resolves(null);
-        expect(await courtRequests.getAllLocations()).toBe(null);
+        expect(await courtRequests.getAllLocations()).toStrictEqual([]);
     });
 
-    it('should return null list of courts for errored response', async () => {
+    it('should return empty list of courts for errored response', async () => {
         stub.withArgs('/locations').rejects(errorResponse);
         stub.withArgs('allCourts').resolves(null);
-        expect(await courtRequests.getAllLocations()).toBe(null);
+        expect(await courtRequests.getAllLocations()).toStrictEqual([]);
     });
 
     it('should not delete the court if active artefact or subscription exists', async () => {

--- a/src/test/unit/service/filterService.test.ts
+++ b/src/test/unit/service/filterService.test.ts
@@ -59,6 +59,12 @@ describe('Filter Service', () => {
         expect(data[jurisdiction][crownCourt]['checked']).toBe(true);
     });
 
+    it('should return empty filter options for empty locations', () => {
+        const data = filterService.buildFilterValueOptions([], []);
+        expect(data[jurisdiction]).toStrictEqual({});
+        expect(data[region]).toStrictEqual({});
+    });
+
     it('should return empty array if clear is set to all', () => {
         expect(filterService.handleFilterClear(['test'], 'all')).toStrictEqual([]);
     });

--- a/src/test/unit/service/locationService.test.ts
+++ b/src/test/unit/service/locationService.test.ts
@@ -54,7 +54,11 @@ const welshLanguage = 'cy';
 const englishLanguageFile = 'sscs-daily-list';
 const deletionResponse = { exists: true, errorMessage: 'test' };
 const requester = 'Test';
-stubCourtsFilter.withArgs('', 'Crown', englishLanguage).returns(hearingsData);
+const crown = 'Crown';
+const magistrates = 'Magistrates';
+
+stubCourtsFilter.withArgs('', crown, englishLanguage).returns(hearingsData);
+stubCourtsFilter.withArgs('', magistrates, englishLanguage).returns([]);
 stubCourt.withArgs(1).returns(hearingsData[0]);
 stubCourtByName.withArgs(validCourt).returns(hearingsData[0]);
 stubCourtByName.withArgs(validWelshCourt).returns(hearingsData[0]);
@@ -155,13 +159,19 @@ describe('Court Service', () => {
     });
 
     it(`should have filtered a ${validCourt} key`, async () => {
-        const data = await courtService.generateFilteredAlphabetisedCourtList('', 'Crown', englishLanguage);
+        const data = await courtService.generateFilteredAlphabetisedCourtList('', crown, englishLanguage);
         expect(validCourt in data['A']).to.be.true;
     });
 
     it(`should return object with ${validKeysCount} keys filtered`, async () => {
-        const data = await courtService.generateFilteredAlphabetisedCourtList('', 'Crown', englishLanguage);
+        const data = await courtService.generateFilteredAlphabetisedCourtList('', crown, englishLanguage);
         expect(Object.keys(data).length).to.equal(validKeysCount);
+    });
+
+    it(`should return empty filtered courts`, async () => {
+        const data = await courtService.generateFilteredAlphabetisedCourtList('', magistrates, englishLanguage);
+        expect(Object.keys(data).length).to.equal(validKeysCount);
+        expect(data['A']).to.be.empty;
     });
 
     it('should return sorted courts list', () => {


### PR DESCRIPTION
### JIRA link

[https://tools.hmcts.net/jira/browse/<PR-name-here>](https://tools.hmcts.net/jira/browse/PUB-2286)

### Change description

PUB-2286 Return empty array for courts when data-management is down

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
