### PR TITLE
PUB-2475 Update allowed postcode format for SJP Public List

### DIFF
--- a/src/test/end-to-end/shared/mocks/sjp-public-list.json
+++ b/src/test/end-to-end/shared/mocks/sjp-public-list.json
@@ -22,7 +22,7 @@
                                                             "individualForenames": "A",
                                                             "individualSurname": "This is a surname",
                                                             "address": {
-                                                                "postCode": "AA1"
+                                                                "postCode": "AA"
                                                             }
                                                         }
                                                     },
@@ -46,7 +46,7 @@
                                                         "organisationDetails": {
                                                             "organisationName": "This is an accused organisation name",
                                                             "organisationAddress": {
-                                                                "postCode": "A99"
+                                                                "postCode": "A9"
                                                             }
                                                         }
                                                     },

--- a/src/test/end-to-end/shared/mocks/sjp-public-list.json
+++ b/src/test/end-to-end/shared/mocks/sjp-public-list.json
@@ -22,7 +22,7 @@
                                                             "individualForenames": "A",
                                                             "individualSurname": "This is a surname",
                                                             "address": {
-                                                                "postCode": "AA"
+                                                                "postCode": "A1"
                                                             }
                                                         }
                                                     },

--- a/src/test/unit/mocks/sjp-public-list.json
+++ b/src/test/unit/mocks/sjp-public-list.json
@@ -22,7 +22,7 @@
                                                             "individualForenames": "A",
                                                             "individualSurname": "This is a surname",
                                                             "address": {
-                                                                "postCode": "AA1"
+                                                                "postCode": "AA"
                                                             }
                                                         }
                                                     },
@@ -46,7 +46,7 @@
                                                         "organisationDetails": {
                                                             "organisationName": "This is an accused organisation name",
                                                             "organisationAddress": {
-                                                                "postCode": "A99"
+                                                                "postCode": "A9"
                                                             }
                                                         }
                                                     },

--- a/src/test/unit/service/listManipulation/SjpPublicListService.test.ts
+++ b/src/test/unit/service/listManipulation/SjpPublicListService.test.ts
@@ -24,12 +24,12 @@ describe('formatSjpPublicList', () => {
 
     it('should return accused postcode using individual details', async () => {
         const data = await sjpPublicListService.formatSjpPublicList(rawSJPData);
-        expect(data[0].postcode).to.equal('AA1');
+        expect(data[0].postcode).to.equal('AA');
     });
 
     it('should return accused postcode using organisation details', async () => {
         const data = await sjpPublicListService.formatSjpPublicList(rawSJPData);
-        expect(data[1].postcode).to.equal('A99');
+        expect(data[1].postcode).to.equal('A9');
     });
 
     it('should return prosecutor', async () => {

--- a/src/test/unit/views/style-guide/single-justice-procedure-public.test.ts
+++ b/src/test/unit/views/style-guide/single-justice-procedure-public.test.ts
@@ -23,8 +23,8 @@ const summaryHeadingText = 'List containing 2 case(s)';
 const listDate = '01 September 2023';
 const offenderIndividualName = 'A This is a surname';
 const offenderOrganisationName = 'This is an accused organisation name';
-const offenderIndividualPostcode = 'AA1';
-const offenderOrganisationPostcode = 'A99';
+const offenderIndividualPostcode = 'AA';
+const offenderOrganisationPostcode = 'A9';
 const offenderProsecutor = 'This is a prosecutor organisation';
 const offenderReason = 'This is an offence title';
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PUB-2475

### Change description ###

Update allowed postcode format for SJP Public List

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
