### PR TITLE
PUB-2508 - Fix SJP Filters issue

### DIFF
--- a/src/main/controllers/style-guide/SjpPressListController.ts
+++ b/src/main/controllers/style-guide/SjpPressListController.ts
@@ -88,7 +88,7 @@ export default class SjpPressListController {
                     pathname: 'sjp-press-list',
                     query: {
                         artefactId: req.query.artefactId as string,
-                        filterValues: filterValues,
+                        filterValues: filterValues.toString(),
                     },
                 })
             );

--- a/src/main/controllers/style-guide/SjpPublicListController.ts
+++ b/src/main/controllers/style-guide/SjpPublicListController.ts
@@ -77,7 +77,7 @@ export default class SjpPublicListController {
             res.redirect(
                 url.format({
                     pathname: 'sjp-public-list',
-                    query: { artefactId: req.query.artefactId as string, filterValues: filterValues },
+                    query: { artefactId: req.query.artefactId as string, filterValues: filterValues.toString() },
                 })
             );
         } else {

--- a/src/main/service/FilterService.ts
+++ b/src/main/service/FilterService.ts
@@ -101,9 +101,9 @@ export class FilterService {
         return filterValueOptions;
     }
 
-    public stripFilters(currentFilters: string): string[] {
+    public stripFilters(currentFilters: string | string[]): string[] {
         if (currentFilters && currentFilters !== ',') {
-            return currentFilters.split(',');
+            return currentFilters.toString().split(',');
         }
         return [];
     }

--- a/src/main/views/macros/sjp-common.njk
+++ b/src/main/views/macros/sjp-common.njk
@@ -22,8 +22,7 @@
                     text: filter.searchFilters,
                     classes: 'govuk-label--m'
                 },
-                id: 'search-filters',
-                name: 'search-filters'
+                id: 'search-filters'
             }) }}
             {% for key, options in filterOptions %}
                 {% set checkedFilterItems = [] %}

--- a/src/test/unit/controllers/style-guide/SjpPressListController.test.ts
+++ b/src/test/unit/controllers/style-guide/SjpPressListController.test.ts
@@ -240,7 +240,7 @@ describe('SJP Press List Controller', () => {
         it('should redirect to configure list page with correct filters', () => {
             const artefactId = sjpPressResource['artefactId'];
             request.query = { artefactId: artefactId };
-            request.body = {}
+            request.body = {};
 
             const responseMock = sinon.mock(response);
             responseMock
@@ -254,7 +254,7 @@ describe('SJP Press List Controller', () => {
         });
 
         it('should redirect to configure list page with a concatenated string when multiple filters selected', () => {
-            request.body = {"value1": "value1", "value2": "value2"}
+            request.body = { value1: 'value1', value2: 'value2' };
             generateKeyValuesStub.withArgs(request.body).returns(['value1', 'value2']);
 
             const artefactId = sjpPressResource['artefactId'];

--- a/src/test/unit/controllers/style-guide/SjpPressListController.test.ts
+++ b/src/test/unit/controllers/style-guide/SjpPressListController.test.ts
@@ -70,7 +70,8 @@ generatesFilesStub.withArgs(sjpPressNewCasesResource['artefactId']).resolves(tru
 generatesFilesStub.withArgs(sjpPressFullListResource['artefactIdWithNoFiles']).resolves(false);
 generatesFilesStub.withArgs(sjpPressNewCasesResource['artefactIdWithNoFiles']).resolves(false);
 
-sinon.stub(FilterService.prototype, 'generateFilterKeyValues').returns('TestValue');
+const generateKeyValuesStub = sinon.stub(FilterService.prototype, 'generateFilterKeyValues');
+generateKeyValuesStub.withArgs({}).returns(['TestValue']);
 
 const i18n = {
     'style-guide': {
@@ -239,6 +240,7 @@ describe('SJP Press List Controller', () => {
         it('should redirect to configure list page with correct filters', () => {
             const artefactId = sjpPressResource['artefactId'];
             request.query = { artefactId: artefactId };
+            request.body = {}
 
             const responseMock = sinon.mock(response);
             responseMock
@@ -251,8 +253,27 @@ describe('SJP Press List Controller', () => {
             });
         });
 
+        it('should redirect to configure list page with a concatenated string when multiple filters selected', () => {
+            request.body = {"value1": "value1", "value2": "value2"}
+            generateKeyValuesStub.withArgs(request.body).returns(['value1', 'value2']);
+
+            const artefactId = sjpPressResource['artefactId'];
+            request.query = { artefactId: artefactId };
+
+            const responseMock = sinon.mock(response);
+            responseMock
+                .expects('redirect')
+                .once()
+                .withArgs(`sjp-press-list?artefactId=${artefactId}&filterValues=value1%2Cvalue2`);
+
+            return sjpPressListController.filterValues(request, response).then(() => {
+                responseMock.verify();
+            });
+        });
+
         it('should redirect to error page if invalid artefact ID provided', () => {
             request.query = { artefactId: 'abcd' };
+            request.body = {};
 
             const responseMock = sinon.mock(response);
             responseMock.expects('render').once().withArgs(`error`);

--- a/src/test/unit/controllers/style-guide/SjpPublicListController.test.ts
+++ b/src/test/unit/controllers/style-guide/SjpPublicListController.test.ts
@@ -72,7 +72,9 @@ generatesFilesStub.withArgs(sjpNewCasesResource['artefactIdWithNoFiles']).resolv
 
 const filter = { sjpCases: ['1', '2'], filterOptions: {} };
 sinon.stub(SjpFilterService.prototype, 'generateFilters').returns(filter);
-sinon.stub(FilterService.prototype, 'generateFilterKeyValues').returns('TestValue');
+
+const generateKeyValuesStub = sinon.stub(FilterService.prototype, 'generateFilterKeyValues');
+generateKeyValuesStub.withArgs({}).returns(['TestValue']);
 
 describe('SJP Public List Type Controller', () => {
     const response = {
@@ -217,6 +219,7 @@ describe('SJP Public List Type Controller', () => {
 
         it('should redirect to configure list page with correct filters', () => {
             request.query = { artefactId: artefactId };
+            request.body = {}
 
             const responseMock = sinon.mock(response);
             responseMock
@@ -229,8 +232,26 @@ describe('SJP Public List Type Controller', () => {
             });
         });
 
+        it('should redirect to configure list page with a concatenated string when multiple filters selected', () => {
+            request.body = {"value1": "value1", "value2": "value2"}
+            generateKeyValuesStub.withArgs(request.body).returns(['value1', 'value2']);
+
+            request.query = { artefactId: artefactId };
+
+            const responseMock = sinon.mock(response);
+            responseMock
+                .expects('redirect')
+                .once()
+                .withArgs(`sjp-public-list?artefactId=${artefactId}&filterValues=value1%2Cvalue2`);
+
+            return sjpPublicListController.filterValues(request, response).then(() => {
+                responseMock.verify();
+            });
+        });
+
         it('should render error page when invalid artefact ID provided', () => {
             request.query = { artefactId: 'abcd' };
+            request.body = {}
 
             const responseMock = sinon.mock(response);
             responseMock.expects('render').once().withArgs(`error`);

--- a/src/test/unit/controllers/style-guide/SjpPublicListController.test.ts
+++ b/src/test/unit/controllers/style-guide/SjpPublicListController.test.ts
@@ -219,7 +219,7 @@ describe('SJP Public List Type Controller', () => {
 
         it('should redirect to configure list page with correct filters', () => {
             request.query = { artefactId: artefactId };
-            request.body = {}
+            request.body = {};
 
             const responseMock = sinon.mock(response);
             responseMock
@@ -233,7 +233,7 @@ describe('SJP Public List Type Controller', () => {
         });
 
         it('should redirect to configure list page with a concatenated string when multiple filters selected', () => {
-            request.body = {"value1": "value1", "value2": "value2"}
+            request.body = { value1: 'value1', value2: 'value2' };
             generateKeyValuesStub.withArgs(request.body).returns(['value1', 'value2']);
 
             request.query = { artefactId: artefactId };
@@ -251,7 +251,7 @@ describe('SJP Public List Type Controller', () => {
 
         it('should render error page when invalid artefact ID provided', () => {
             request.query = { artefactId: 'abcd' };
-            request.body = {}
+            request.body = {};
 
             const responseMock = sinon.mock(response);
             responseMock.expects('render').once().withArgs(`error`);

--- a/src/test/unit/service/FilterService.test.ts
+++ b/src/test/unit/service/FilterService.test.ts
@@ -132,6 +132,12 @@ describe('Filter Service', () => {
         expect(filterService.stripFilters(null)).toStrictEqual([]);
     });
 
+    it('should return array from array of strings', () => {
+        expect(filterService.stripFilters(['test,filter', 'test2']))
+            .toEqual(['test', 'filter', 'test2']);
+    });
+
+
     it('should return object for rendering with no clear or filters selected', async () => {
         expect(await filterService.handleFilterInitialisation(null, null, englishLanguage)).toStrictEqual({
             alphabetisedList: listData,

--- a/src/test/unit/service/FilterService.test.ts
+++ b/src/test/unit/service/FilterService.test.ts
@@ -133,10 +133,8 @@ describe('Filter Service', () => {
     });
 
     it('should return array from array of strings', () => {
-        expect(filterService.stripFilters(['test,filter', 'test2']))
-            .toEqual(['test', 'filter', 'test2']);
+        expect(filterService.stripFilters(['test,filter', 'test2'])).toEqual(['test', 'filter', 'test2']);
     });
-
 
     it('should return object for rendering with no clear or filters selected', async () => {
         expect(await filterService.handleFilterInitialisation(null, null, englishLanguage)).toStrictEqual({


### PR DESCRIPTION
### JIRA link

https://tools.hmcts.net/jira/browse/PUB-2508

### Change description

NodeJS was crashing on SJP filters due to the way the filterValues are handled.

This is to fix the filter values. I have also removed the search input from being submitted in the form, as this is not used in the backend

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
